### PR TITLE
updated windows workflow to jwlawson/actions-setup-cmake@v1.13.1

### DIFF
--- a/.github/workflows/continuous-windows.yml
+++ b/.github/workflows/continuous-windows.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v3
         
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v1.9
+      uses: jwlawson/actions-setup-cmake@v1.13.1
       with:
         cmake-version: '3.21.x'
 


### PR DESCRIPTION
Updated to  `jwlawson/actions-setup-cmake@v1.13.1` in the windows workflow so as to avoid the Node.js 12 deprecation warning (it was updated to Node.js 16 in v1.13.0).

fixes #221