### PR TITLE
switch_to_spack-0.19.2

### DIFF
--- a/.github/workflows/env_linux.sh
+++ b/.github/workflows/env_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-git clone --depth=1 -b releases/latest https://github.com/spack/spack.git
+git clone --depth=1 -b v0.19.2 https://github.com/spack/spack.git
 sed -i 's#"${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}"#"${PACKAGE}"#g' spack/etc/spack/defaults/config.yaml
 . ./spack/share/spack/setup-env.sh
 

--- a/.github/workflows/env_macos.sh
+++ b/.github/workflows/env_macos.sh
@@ -2,7 +2,7 @@
 
 brew install autoconf automake libtool gcc
 
-git clone --depth=1 -b releases/latest https://github.com/spack/spack.git
+git clone --depth=1 -b v0.19.2 https://github.com/spack/spack.git
 
 #replace the default configuration file of spack by a simpler one without hash, compiler versions, tags and so on 
 cp /Users/runner/work/gmds/gmds/.github/workflows/misc/config.yaml /Users/runner/work/gmds/gmds/spack/etc/spack/defaults/


### PR DESCRIPTION
The bypass we used to force the installation of the dependencies using `spack` to avoid the plateform/compiler/hash no longer works with the latest release `0.20.0`.

Here we temporarily switched back to `v0.19.2`.