### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,8 +274,8 @@ GMDS_ADD_COMPONENT(
         rlBlocking                       # src subdirectory name
         GMDSRlBlocking                    # name of the generated library
         " "  # description
-        ON                                 # is activated
-        ON                                 # must be covered
+        OFF                                 # is activated
+        OFF                                 # must be covered
 )
 
 


### PR DESCRIPTION
the RLBlocking is a research component that is not stable and will likely be removed in the next months. We should not put in the non-reg procedure