### PR TITLE
Issue 260 mesh doctor build e on a 3 d mesh model with r and r2 n but which has only f created

### DIFF
--- a/ig/inc/gmds/ig/MeshDoctor.h
+++ b/ig/inc/gmds/ig/MeshDoctor.h
@@ -67,9 +67,11 @@ namespace gmds{
         void  buildF() const;
 
         /*------------------------------------------------------------------------*/
-        /** \brief create faces
+        /** \brief create edges, from R if present in the model, or from F if R is not present
          */
         void  buildE() const;
+	     void  buildEfromF() const;
+	     void  buildEfromR() const;
 
         /*------------------------------------------------------------------------*/
         /** \brief Fill up the X2Y connectivity for m_mesh

--- a/ig/tst/MeshDoctorTestSuite.h
+++ b/ig/tst/MeshDoctorTestSuite.h
@@ -39,22 +39,35 @@ TEST(MeshDocClass, buildE)
 	gmds::Mesh m(gmds::MeshModel(DIM3 | R | F | E | N | R2N | F2N | E2N | R2F | F2R |
 	                             F2E | E2F | R2E | E2R | N2R | N2F | N2E));
 
-	gmds::Node n0 = m.newNode(0,0,0);
-	gmds::Node n1 = m.newNode(1,1,0);
-	gmds::Node n2 = m.newNode(0,1,0);
-	gmds::Node n3 = m.newNode(1,0,0);
+	gmds::Node n0 = m.newNode(0,0,1);
+	gmds::Node n1 = m.newNode(1,0,1);
+	gmds::Node n2 = m.newNode(1,1,1);
+	gmds::Node n3 = m.newNode(0,1,1);
+	gmds::Node n4 = m.newNode(0,0,1);
+	gmds::Node n5 = m.newNode(1,0,1);
+	gmds::Node n6 = m.newNode(1,1,1);
+	gmds::Node n7 = m.newNode(0,1,1);
 
-	m.newTriangle(n0,n1,n3);
-	m.newTriangle(n0,n3,n2);
+	m.newTriangle(n0,n1,n2);
+	m.newTriangle(n0,n2,n3);
 	m.newQuad(n0,n1,n2,n3);
 
 	ASSERT_EQ(m.getNbEdges(), 0);
-
-	std::cout << "1. Nbr edges: " << m.getNbEdges() << std::endl;
 	gmds::MeshDoctor doc(&m);
 	doc.buildE();
-	std::cout << "2. Nbr edges: " << m.getNbEdges() << std::endl;
+	ASSERT_EQ(m.getNbEdges(), 0);
+	m.newEdge(n0,n7);
+	ASSERT_EQ(m.getNbEdges(), 1);
+	doc.buildEfromR();
+	ASSERT_EQ(m.getNbEdges(), 1);
+	doc.buildEfromF();
+	ASSERT_EQ(m.getNbEdges(), 6);
+
+	m.newHex(n0,n1,n2,n3,n4,n5,n6,n7);
+	m.newPyramid(n0,n3,n7,n4,n1);
+	m.newPrism3(n0,n1,n2,n4,n5,n6);
+	doc.buildEfromR();
+	ASSERT_EQ(m.getNbEdges(), 18);
 
 }
-
 /*----------------------------------------------------------------------------*/

--- a/ig/tst/MeshDoctorTestSuite.h
+++ b/ig/tst/MeshDoctorTestSuite.h
@@ -34,4 +34,27 @@ TEST(MeshDocClass, buildN2F)
     ASSERT_EQ(n3.get<gmds::Face>().size(),3);
 }
 
+TEST(MeshDocClass, buildE)
+{
+	gmds::Mesh m(gmds::MeshModel(DIM3 | R | F | E | N | R2N | F2N | E2N | R2F | F2R |
+	                             F2E | E2F | R2E | E2R | N2R | N2F | N2E));
+
+	gmds::Node n0 = m.newNode(0,0,0);
+	gmds::Node n1 = m.newNode(1,1,0);
+	gmds::Node n2 = m.newNode(0,1,0);
+	gmds::Node n3 = m.newNode(1,0,0);
+
+	m.newTriangle(n0,n1,n3);
+	m.newTriangle(n0,n3,n2);
+	m.newQuad(n0,n1,n2,n3);
+
+	ASSERT_EQ(m.getNbEdges(), 0);
+
+	std::cout << "1. Nbr edges: " << m.getNbEdges() << std::endl;
+	gmds::MeshDoctor doc(&m);
+	doc.buildE();
+	std::cout << "2. Nbr edges: " << m.getNbEdges() << std::endl;
+
+}
+
 /*----------------------------------------------------------------------------*/


### PR DESCRIPTION
closes #260 by implementing `MeshDoctor::buildEfromF` and `buildEfromR` methods