### PR TITLE
Pillow operation added to the curved blocking

### DIFF
--- a/blocking/src/CurvedBlocking.cpp
+++ b/blocking/src/CurvedBlocking.cpp
@@ -400,14 +400,14 @@ CurvedBlocking::create_block(
     Dart3 d1 = m_gmap.make_combinatorial_hexahedron();
 
     // 0D attribute
-    m_gmap.set_attribute<0>(d1, create_node(1, 4, AP1));
-    m_gmap.set_attribute<0>(m_gmap.alpha<0>(d1), create_node(1, 4, AP2));
-    m_gmap.set_attribute<0>(m_gmap.alpha<0, 1, 0>(d1), create_node(1, 4, AP3));
-    m_gmap.set_attribute<0>(m_gmap.alpha<1, 0>(d1), create_node(1, 4, AP4));
-    m_gmap.set_attribute<0>(m_gmap.alpha<2, 1, 0, 1, 2>(d1), create_node(1, 4, AP5));
-    m_gmap.set_attribute<0>(m_gmap.alpha<2, 1, 0, 1, 2, 0, 1>(d1), create_node(1, 4, AP6));
-    m_gmap.set_attribute<0>(m_gmap.alpha<2, 1, 0, 1, 2, 0, 1, 0, 1>(d1), create_node(1, 4, AP7));
-    m_gmap.set_attribute<0>(m_gmap.alpha<2, 1, 0, 1, 2, 1, 0>(d1), create_node(1, 4, AP8));
+    m_gmap.set_attribute<0>(d1, create_node(4, NullID, AP1));
+    m_gmap.set_attribute<0>(m_gmap.alpha<0>(d1), create_node(4, NullID, AP2));
+    m_gmap.set_attribute<0>(m_gmap.alpha<0, 1, 0>(d1), create_node(4, NullID, AP3));
+    m_gmap.set_attribute<0>(m_gmap.alpha<1, 0>(d1), create_node(4, NullID, AP4));
+    m_gmap.set_attribute<0>(m_gmap.alpha<2, 1, 0, 1, 2>(d1), create_node(4, NullID, AP5));
+    m_gmap.set_attribute<0>(m_gmap.alpha<2, 1, 0, 1, 2, 0, 1>(d1), create_node(4, NullID, AP6));
+    m_gmap.set_attribute<0>(m_gmap.alpha<2, 1, 0, 1, 2, 0, 1, 0, 1>(d1), create_node(4, NullID, AP7));
+    m_gmap.set_attribute<0>(m_gmap.alpha<2, 1, 0, 1, 2, 1, 0>(d1), create_node(4, NullID, AP8));
 
     // go through all the edges
     for (auto it = m_gmap.one_dart_per_incident_cell<1, 3>(d1).begin(), itend = m_gmap.one_dart_per_incident_cell<1, 3>(
@@ -420,7 +420,7 @@ CurvedBlocking::create_block(
             d1).end(); it != itend; ++it) {
         m_gmap.set_attribute<2>(it, create_face(4, NullID));
     }
-    Block b = create_block(4, NullID);
+    Block b = create_block(3, NullID);
     m_gmap.set_attribute<3>(d1, b);
     return b;
 }
@@ -612,14 +612,14 @@ CurvedBlocking::init_from_mesh(Mesh &AMesh) {
                                    ns[4].point(), ns[5].point(), ns[6].point(), ns[7].point());
             std::vector<Node> b_nodes = get_nodes_of_block(b);
             for (auto i = 0; i < 8; i++) {
-                math::Point pi =ns[i].point();
+                math::Point pi = ns[i].point();
                 auto min_dist = pi.distance2(b_nodes[0]->info().point);
                 auto min_id = b_nodes[0]->info().topo_id;
-                for(auto j=1; j<8;j++){
-                    auto dist_j= pi.distance2(b_nodes[j]->info().point);
-                    if(dist_j<min_dist){
-                        min_dist=dist_j;
-                        min_id =b_nodes[j]->info().topo_id;
+                for (auto j = 1; j < 8; j++) {
+                    auto dist_j = pi.distance2(b_nodes[j]->info().point);
+                    if (dist_j < min_dist) {
+                        min_dist = dist_j;
+                        min_id = b_nodes[j]->info().topo_id;
                     }
                 }
                 n2n[min_id] = ns[i].id();
@@ -628,8 +628,7 @@ CurvedBlocking::init_from_mesh(Mesh &AMesh) {
     }
 
     // now we glue blocks;
-    for (auto it_r = m_gmap.attributes<3>().begin(), it_rend = m_gmap.attributes<3>().end(); it_r != it_rend; ++it_r)
-    {
+    for (auto it_r = m_gmap.attributes<3>().begin(), it_rend = m_gmap.attributes<3>().end(); it_r != it_rend; ++it_r) {
         std::vector<Face> cell_faces = get_faces_of_block(it_r);
         for (auto f: cell_faces) {
             Dart3 d = f->dart();
@@ -776,36 +775,36 @@ CurvedBlocking::get_all_sheet_darts(const Edge AE, std::vector<Dart3> &ADarts) {
     }
     m_gmap.free_mark(edge_mark);
 }
-/*----------------------------------------------------------------------------*/
-std::vector<CurvedBlocking::Block> CurvedBlocking::get_all_chord_blocks(const Face AF)
-{
-  std::vector<CurvedBlocking::Block> bls;
-  auto block_mark = m_gmap.get_new_mark();
 
-  std::vector<Dart3> face_darts;
-  get_all_chord_darts(AF, face_darts);
-  for(auto d: face_darts){
-      if(!m_gmap.is_marked(d,block_mark)) {
-          bls.push_back(m_gmap.attribute<3>(d));
-          m_gmap.mark_cell<3>(d,block_mark);
-      }
-      if(!m_gmap.is_marked(m_gmap.alpha<3>(d),block_mark)) {
-          bls.push_back(m_gmap.attribute<3>(m_gmap.alpha<3>(d)));
-          m_gmap.mark_cell<3>(m_gmap.alpha<3>(d),block_mark);
-      }
-  }
+/*----------------------------------------------------------------------------*/
+std::vector<CurvedBlocking::Block> CurvedBlocking::get_all_chord_blocks(const Face AF) {
+    std::vector<CurvedBlocking::Block> bls;
+    auto block_mark = m_gmap.get_new_mark();
+
+    std::vector<Dart3> face_darts;
+    get_all_chord_darts(AF, face_darts);
+    for (auto d: face_darts) {
+        if (!m_gmap.is_marked(d, block_mark)) {
+            bls.push_back(m_gmap.attribute<3>(d));
+            m_gmap.mark_cell<3>(d, block_mark);
+        }
+        if (!m_gmap.is_marked(m_gmap.alpha<3>(d), block_mark)) {
+            bls.push_back(m_gmap.attribute<3>(m_gmap.alpha<3>(d)));
+            m_gmap.mark_cell<3>(m_gmap.alpha<3>(d), block_mark);
+        }
+    }
 
     // We must unmark all the marked edges. As we stored one dart per edge, it is straightforward
     for (auto b: bls) {
         m_gmap.unmark_cell<3>(b->dart(), block_mark);
     }
     m_gmap.free_mark(block_mark);
-  return bls;
+    return bls;
 }
+
 /*----------------------------------------------------------------------------*/
 void
-CurvedBlocking::get_all_chord_darts(const Face AF, std::vector<Dart3> &ADarts)
-{
+CurvedBlocking::get_all_chord_darts(const Face AF, std::vector<Dart3> &ADarts) {
     ADarts.clear();
     // we allocate a mark to know all the faces we go through
     auto face_mark = m_gmap.get_new_mark();
@@ -949,7 +948,8 @@ CurvedBlocking::cut_sheet(const Edge AE, const double AParam) {
             } while (current_dart != d);
             auto face_att = m_gmap.attribute<2>(d)->info();
             Dart3 d_block = m_gmap.insert_cell_2_in_cell_3(loop_darts.begin(), loop_darts.end());
-            m_gmap.set_attribute<2>(d_block, create_face(face_att.geom_dim, face_att.geom_id));
+            // a face is created by splitting a block, it is classified on a 3-dimensional geom cell
+            m_gmap.set_attribute<2>(d_block, create_face(3, NullID));
         }
     }
     // we free the mark after unmarking all the darts. This is not optimal.
@@ -994,6 +994,649 @@ CurvedBlocking::get_projection_info(math::Point &AP, std::vector<CurvedBlocking:
 
 /*----------------------------------------------------------------------------*/
 bool
+CurvedBlocking::validate_pillowing_surface(std::vector<Face> &AFaces) {
+    auto mark_face = m_gmap.get_new_mark();
+    for (auto f: AFaces) {
+        m_gmap.mark_cell<2>(f->dart(), mark_face);
+    }
+
+    //Now, we have a manifold surface if for each face f of AFace, every edge adjacent to f:
+    // 1. has exactly two adjacent faces in AF, OR
+    // 2. has only one adjacent faces, but is classified on a curve or a surface
+    bool found_error = false;
+    for (int i_f = 0; i_f < AFaces.size() && !found_error; i_f++) {
+        Face fi = AFaces[i_f];
+        std::vector<CurvedBlocking::Edge> edges_of_fi = get_edges_of_face(fi);
+        for (auto e: edges_of_fi) {
+            std::vector<CurvedBlocking::Face> faces_of_e = get_faces_of_edge(e);
+            int nb_faces_in_pillow_surface = 0;
+            int nb_faces_in_pillow_surface_on_boundary = 0;
+            for (auto f_of_e: faces_of_e) {
+                if (m_gmap.is_marked(f_of_e->dart(), mark_face)) {
+                    nb_faces_in_pillow_surface++;
+                    if (f_of_e->info().geom_dim == 2)
+                        nb_faces_in_pillow_surface_on_boundary++;
+                }
+            }
+            if (nb_faces_in_pillow_surface < 1 || nb_faces_in_pillow_surface > 2)
+                found_error = true;
+            else if (nb_faces_in_pillow_surface == 1) {
+                //We have two cases
+                //The face is on the boundary, so the edge must be on a curve
+                if (nb_faces_in_pillow_surface_on_boundary == 1 && e->info().geom_dim != 1)
+                    found_error = true;
+                //if the face is inside the volume, the edge must be on curve or a surface
+                if (nb_faces_in_pillow_surface_on_boundary == 0 &&
+                    !(e->info().geom_dim != 1 || e->info().geom_dim != 2))
+                    found_error = true;
+            }
+            //else we have two faces, it is okay.
+        }
+    }
+
+    for (auto f: AFaces) {
+        m_gmap.unmark_cell<2>(f->dart(), mark_face);
+    }
+    m_gmap.free_mark(mark_face);
+
+    return !found_error;
+}
+/*----------------------------------------------------------------------------*/
+void CurvedBlocking::mark_half_face(gmds::blocking::Dart3 ADart, int AMark) {
+    Dart3 d = ADart;
+    do {
+        m_gmap.mark(d, AMark);
+        m_gmap.mark(m_gmap.alpha<0>(d), AMark);
+        d = m_gmap.alpha<0, 1>(d);
+    } while (d != ADart);
+}
+/*----------------------------------------------------------------------------*/
+std::tuple<int, int, int, int>
+CurvedBlocking::compute_pillow_twin_node(const Node &ANode, const int AMark) {
+    Dart3 d = ANode->dart();
+    //We traverse the node set of darts to get a blue one
+    bool found_blue_dart = false;
+    Dart3 blue_dart;
+    for (auto it(m_gmap.darts_of_orbit<1, 2, 3>(d).begin()),
+                 itend(m_gmap.darts_of_orbit<1, 2, 3>(d).end());
+         it != itend && !found_blue_dart; ++it) {
+        if (m_gmap.is_marked(it, AMark)) {
+            found_blue_dart = true;
+            blue_dart = it;
+        }
+    }
+    //we turn in the vertex of blue dart to count the number of blue faces adjacent to the node
+    //we get one dart for each face (2) incident to the vertex (0) containing d
+    auto nb_incident_blue_faces = 0;
+    for (auto it = m_gmap.one_dart_per_incident_cell<2, 0>(blue_dart).begin(),
+                 itend = m_gmap.one_dart_per_incident_cell<2, 0>(blue_dart).end(); it != itend; ++it) {
+
+        auto fi = m_gmap.attribute<2>(it);
+        if (m_gmap.is_marked(it, AMark) || m_gmap.is_marked(m_gmap.alpha<3>(it), AMark)) {
+            nb_incident_blue_faces++;
+        }
+    }
+    auto nb_incident_blue_blocks = 0;
+    auto mark_block = m_gmap.get_new_mark();
+    for (auto it = m_gmap.one_dart_per_incident_cell<3, 0>(blue_dart).begin(),
+                 itend = m_gmap.one_dart_per_incident_cell<3, 0>(blue_dart).end(); it != itend; ++it) {
+        //We have one dart of the block (the dart belongs to the vertex too
+        auto found_blue_dart_in_block = false;
+        m_gmap.mark_cell<3>(it, mark_block);
+        for (auto it2 = m_gmap.one_dart_per_incident_cell<2, 0>(it).begin(),
+                     it2end = m_gmap.one_dart_per_incident_cell<2, 0>(it).end(); it2 != it2end; ++it2) {
+            //the provided dart does not necessary belong to the block
+            if (m_gmap.is_marked(it2, AMark) && m_gmap.is_marked(it2, mark_block)) {
+                found_blue_dart_in_block = true;
+            } else if (m_gmap.is_marked(m_gmap.alpha<3>(it2), AMark) &&
+                       m_gmap.is_marked(m_gmap.alpha<3>(it2), mark_block)) {
+                found_blue_dart_in_block = true;
+            }
+        }
+        if (found_blue_dart_in_block) {
+            nb_incident_blue_blocks++;
+        }
+        m_gmap.unmark_cell<3>(it, mark_block);
+    }
+    m_gmap.free_mark(mark_block);
+    int cell_topo_dim = 0;
+    int cell_topo_id = 0;
+    int cell_geom_dim = 0;
+    int cell_geom_id = 0;
+    //We know the number of incident blue faces and blue blocks
+    if ((nb_incident_blue_faces == 1 && nb_incident_blue_blocks == 1) ||
+        (nb_incident_blue_faces == 2 && nb_incident_blue_blocks == 2) ||
+        (nb_incident_blue_faces == 3 && nb_incident_blue_blocks == 3) ||
+        (nb_incident_blue_faces > 3 && nb_incident_blue_blocks == nb_incident_blue_faces)) {
+        //slide along a boundary edge
+        //the blue dart belongs to the node, the face and block
+        Dart3 edge_dart = m_gmap.alpha<2, 1>(blue_dart);
+        auto edge_info = m_gmap.attribute<1>(edge_dart);
+        cell_topo_dim = edge_info->info().topo_dim;
+        cell_topo_id = edge_info->info().topo_id;
+        cell_geom_dim = edge_info->info().geom_dim;
+        cell_geom_id = edge_info->info().geom_id;
+    } else if ((nb_incident_blue_faces == 2 && nb_incident_blue_blocks == 1) ||
+               (nb_incident_blue_faces == 4 && nb_incident_blue_blocks == 2)) {
+        //slide along a  face
+        //the blue dart belongs to the node, the face and block
+        Dart3 face_dart = m_gmap.alpha<2>(blue_dart);
+        if (m_gmap.is_marked(face_dart, AMark)) {
+            //we pick the third face adjacent to the node and that belongs to the block
+            face_dart = m_gmap.alpha<1, 2>(blue_dart);
+        }
+        auto face_info = m_gmap.attribute<2>(face_dart);
+        cell_topo_dim = face_info->info().topo_dim;
+        cell_topo_id = face_info->info().topo_id;
+        cell_geom_dim = face_info->info().geom_dim;
+        cell_geom_id = face_info->info().geom_id;
+
+    } else if (nb_incident_blue_faces == 3 && nb_incident_blue_blocks == 1) {
+        //get inside a block
+        auto block_info = m_gmap.attribute<3>(blue_dart);
+        cell_topo_dim = block_info->info().topo_dim;
+        cell_topo_id = block_info->info().topo_id;
+        cell_geom_dim = block_info->info().geom_dim;
+        cell_geom_id = block_info->info().geom_id;
+    } else {
+        throw GMDSException("Unmanaged node configuration during the pillowing preparation");
+    }
+
+    return std::make_tuple(cell_topo_dim, cell_topo_id, cell_geom_dim, cell_geom_id);
+}
+
+/*----------------------------------------------------------------------------*/
+bool
+CurvedBlocking::pillow(std::vector<Face> &AFaces) {
+    bool is_input_ok = validate_pillowing_surface(AFaces);
+    if (!is_input_ok)
+        return false;
+
+    auto mark_face = m_gmap.get_new_mark();
+    for (auto f: AFaces) {
+        m_gmap.mark_cell<2>(f->dart(), mark_face);
+    }
+
+    //Now, we have a manifold surface, we color each side of the surface with a different color
+    auto mark_blue_side = m_gmap.get_new_mark();
+    auto mark_red_side = m_gmap.get_new_mark();
+
+    //we first color a seed face. If we have a volumetric face, we color it, otherwise, it will be a boundary face
+    //and we will only use the blue color
+    bool found_seed = false;
+    bool only_boundary_faces = false;
+    for (auto i_f = 0; i_f < AFaces.size() && !found_seed; i_f++) {
+        Dart3 di = AFaces[i_f]->dart();
+        if (!m_gmap.is_free<3>(di)) {
+            //in-volume face
+            found_seed = true;
+            //We mark all darts of di side in blue
+            mark_half_face(di, mark_blue_side);
+            //and the opposite in red
+            mark_half_face(m_gmap.alpha<3>(di), mark_red_side);
+        }
+    }
+    if (!found_seed) {
+        //means we only have boundary faces. We color all of them in blue
+        only_boundary_faces = true;
+        for (auto f: AFaces) {
+            m_gmap.mark_cell<2>(f->dart(), mark_blue_side);
+        }
+    } else
+    {
+        bool all_sides_colored = false;
+        //only one face has its two sides colored in red and blue
+        while (!all_sides_colored) {
+            all_sides_colored = true;
+            for (auto f: AFaces) {
+                auto d = f->dart();
+                if (!m_gmap.is_marked(d, mark_blue_side) && !m_gmap.is_marked(d, mark_red_side)) {
+                    //this face is not colored
+                    all_sides_colored = false;
+                    //now we try to color it
+                    //For that we turn around all its edges to find
+                    Dart3 current_dart = d;
+
+                    auto color_current_face = false;
+                    do {
+                        //does a dart of the edge containing current dart is colored?
+                        Dart3 edge_dart = m_gmap.alpha<2>(current_dart);
+                        auto found_blue = false;
+                        auto found_red = false;
+                        do {
+                            if (m_gmap.is_marked(edge_dart, mark_blue_side)) {
+                                found_blue = true;
+                            } else if (m_gmap.is_marked(edge_dart, mark_red_side)) {
+                                found_red = true;
+                            } else {
+                                //we go to the next dart
+                                edge_dart = m_gmap.alpha<3, 2>(edge_dart);
+                            }
+                        } while (edge_dart != current_dart && edge_dart != m_gmap.alpha<2>(current_dart) &&
+                                !found_blue && !found_red);
+                        // color the face?
+                        if (found_blue) {
+                            color_current_face = true;
+                            //We mark all darts of di side in blue
+                            mark_half_face(current_dart, mark_blue_side);
+                            //and the opposite in red (if it exists)
+                            if(!m_gmap.is_free<3>(current_dart)) {
+                                mark_half_face(m_gmap.alpha<3>(current_dart), mark_red_side);
+                            }
+                        } else if (found_red) {
+                            color_current_face = true;
+                            //We mark all darts of di side in red
+                            mark_half_face(current_dart, mark_red_side);
+                            //and the opposite in blue (if it exists)
+                            if(!m_gmap.is_free<3>(current_dart)) {
+                                mark_half_face(m_gmap.alpha<3>(current_dart), mark_blue_side);
+                            }
+                        }
+                        //we go to the next dart
+                        current_dart = m_gmap.alpha<0, 1>(current_dart);
+                    } while (current_dart != d && !color_current_face);
+                }
+            }
+        }
+
+        //We check the number of blue and red half-faces. We work with the blue half-faces only and their number
+        //must be the greatest
+        int nb_only_blue=0, nb_only_red=0, nb_blue_and_red=0;
+        for(auto f: AFaces){
+            Dart3 d = f->dart();
+            if(m_gmap.is_free<3>(d)){
+                if(m_gmap.is_marked(d,mark_blue_side))
+                    nb_only_blue++;
+                else if(m_gmap.is_marked(d,mark_red_side))
+                    nb_only_red++;
+                else
+                    throw GMDSException("Error during blue-red coloring of face");
+            }
+            else if ((m_gmap.is_marked(d,mark_blue_side) && m_gmap.is_marked(m_gmap.alpha<3>(d),mark_red_side)) ||
+                     (m_gmap.is_marked(d,mark_red_side) && m_gmap.is_marked(m_gmap.alpha<3>(d),mark_blue_side))){
+                nb_blue_and_red++;
+            }
+            else
+                throw GMDSException("Error during blue-red coloring of face");
+        }
+        if(nb_only_blue<nb_only_red){
+            //we switch the blue and red mark, we work on blue only
+            auto temp_mark = mark_blue_side;
+            mark_blue_side = mark_red_side;
+            mark_red_side  = temp_mark;
+        }
+        else if (nb_only_red==nb_only_blue && nb_only_red!=0){
+            //we don't handle this situation right now, we have to quit the function
+            //we clean boolean marks before leaving
+            m_gmap.unmark_all(mark_face);
+            m_gmap.unmark_all(mark_blue_side);
+            m_gmap.unmark_all(mark_red_side);
+            m_gmap.free_mark(mark_face);
+            m_gmap.free_mark(mark_blue_side);
+            m_gmap.free_mark(mark_red_side);
+            return false;
+        }
+    }
+
+    // Now we pillow towards blue side
+    bool non_symetric_blue_red = false;
+    //we get all the nodes and edges of the faces to pillow
+    std::set<Node> surf_nodes;
+    std::set<Edge> surf_edges;
+    for (auto f: AFaces) {
+        std::vector<Node> nodes_of_f = get_nodes_of_face(f);
+        for (auto n: nodes_of_f)
+            surf_nodes.insert(n);
+        std::vector<Edge> edges_of_f = get_edges_of_face(f);
+        for (auto e: edges_of_f)
+            surf_edges.insert(e);
+    }
+    //now for each surface node, we construct the data that will help us to move it afterward
+    std::map<Dart3, std::tuple<int, int, int, int> > pillow_node_data;
+    for (auto n: surf_nodes) {
+        auto pillow_data = compute_pillow_twin_node(n, mark_blue_side);
+        for (GMap3::Dart_of_orbit_range<1, 2, 3>::iterator it(m_gmap.darts_of_orbit<1, 2, 3>(n->dart()).begin()), itend(
+                m_gmap.darts_of_orbit<1, 2, 3>(n->dart()).end()); it != itend; ++it) {
+            pillow_node_data[it] = pillow_data;
+        }
+    }
+    //We deduce from this information each new edge classification (nothing done right now for
+    //faces that become in-volume)
+    //For each old edge id, we keep in mind the geometric data for the new edge
+    std::map<Dart3, std::pair<int, int> > pillow_edge_data;
+
+    for (auto e: surf_edges) {
+        Dart3 d_edge = e->dart();
+        auto [n0_tdim, n0_tid, n0_gdim, n0_gid] = pillow_node_data[d_edge];
+        auto [n1_tdim, n1_tid, n1_gdim, n1_gid] = pillow_node_data[m_gmap.alpha<0>(d_edge)];
+   //     std::cout << "(" << n0_gdim << ", " << n0_gid << ") - (" << n1_gdim << ", " << n1_gid << ")" << std::endl;
+        auto edge_dim = 4;
+        auto edge_id = NullID;
+        if (n0_gdim == n1_gdim && n1_gid == n0_gid) {
+            //the 2 nodes are moved on the same entity, and so the edge
+            edge_dim = n0_gdim;
+            edge_id = n0_gid;
+        } else if (n0_gdim == 2 && n1_gdim == 2 && n1_gid != n0_gid) {
+            //the 2 nodes are moved onto different surfaces, the edge is in a volume
+            edge_dim = 3;
+            edge_id = NullID;
+        } else if (n0_gdim == 1 && n1_gdim == 1 && n1_gid != n0_gid) {
+            //the 2 nodes are moved along different curves, we need the common surface
+            //We need to find this surface!
+            cad::GeomCurve *c0 = m_geom_model->getCurve(n0_gid);
+            cad::GeomCurve *c1 = m_geom_model->getCurve(n1_gid);
+            auto s01_id = m_geom_model->getCommonSurface(c0, c1);
+            edge_dim = 2;
+            edge_id = s01_id;
+        } else if (n0_gdim < n1_gdim) {
+            //the edge is on the n1 entity
+            edge_dim = n1_gdim;
+            edge_id = n1_gid;
+        } else if (n0_gdim > n1_gdim) {
+            //the edge is on the n0 entity
+            edge_dim = n0_gdim;
+            edge_id = n0_gid;
+        }
+        for (GMap3::Dart_of_orbit_range<0, 2, 3>::iterator it(m_gmap.darts_of_orbit<0, 2, 3>(d_edge).begin()), itend(
+                m_gmap.darts_of_orbit<0, 2, 3>(d_edge).end()); it != itend; ++it) {
+            pillow_edge_data[it] = std::make_pair(edge_dim, edge_id);
+   //         std::cout << "Edge data (" << edge_dim << ", " << edge_id << ")" << std::endl;
+        }
+    }
+
+    //We add a mark in order to avoid to reassign node attributes to many times. Moreover, the key of the
+    // pillow_node_data map is the topo node id that will likely change afet a 3-sew (since node attributes will be
+    // merged)
+
+    //We are going first by unsewing some darts and keeping the info
+    std::vector<Dart3> blue_darts;
+    for (auto f: AFaces) {
+        Dart3 df = f->dart();
+        //We are going to duplicate this face
+        if (m_gmap.is_marked(df, mark_blue_side))
+            blue_darts.push_back(df);
+        else
+            blue_darts.push_back(m_gmap.alpha<3>(df));
+    }
+    //we go through blue darts only
+    //for each blue dart, we keep in mind if it was sewed and we unsew if necessary
+    std::map<Dart3,bool> was_sewed;
+    std::map<Dart3,Dart3> prev_3_dart;
+
+    for(auto d: blue_darts){
+        if(m_gmap.is_free<3>(d)){
+            was_sewed[d]=false;
+        }
+        else{
+            was_sewed[d]=true;
+            prev_3_dart[d]=m_gmap.alpha<3>(d);
+            m_gmap.unsew<3>(d);
+        }
+    }
+
+    auto mark_already_merged_node = m_gmap.get_new_mark();
+    auto mark_already_merged_edge = m_gmap.get_new_mark();
+    for (auto df: blue_darts) {
+        //We are going to duplicate this face
+        Face f = m_gmap.attribute<2>(df);
+        //df is blue
+        std::vector<Node> nodes_of_f = get_nodes_of_face(f);
+        Block b = create_block(nodes_of_f[0]->info().point, nodes_of_f[1]->info().point, nodes_of_f[2]->info().point,
+                               nodes_of_f[3]->info().point,
+                               nodes_of_f[0]->info().point, nodes_of_f[1]->info().point, nodes_of_f[2]->info().point,
+                               nodes_of_f[3]->info().point);
+        Dart3 db = b->dart();
+        //we must find the dart to 3-sew with df
+        math::Point df_point = m_gmap.attribute<0>(df)->info().point;
+        double dist_min = df_point.distance2(m_gmap.attribute<0>(db)->info().point);
+        Dart3 db_min = db;
+        Dart3 db_cur = m_gmap.alpha<0, 1>(db);
+        while (db_cur != db) {
+            double dist_cur = df_point.distance2(m_gmap.attribute<0>(db_cur)->info().point);
+            if (dist_cur < dist_min) {
+                dist_min = dist_cur;
+                db_min = db_cur;
+            }
+            db_cur = m_gmap.alpha<0, 1>(db_cur);
+        }
+        //We must now to check if df must be sewed to db_min or a<1>(db_min)
+        math::Point pnt_df0 = m_gmap.attribute<0>(m_gmap.alpha<0>(df))->info().point;
+        math::Point pnt_db_min0 = m_gmap.attribute<0>(m_gmap.alpha<0>(db_min))->info().point;
+        math::Point pnt_db_min10 = m_gmap.attribute<0>(m_gmap.alpha<1, 0>(db_min))->info().point;
+        if (pnt_db_min10.distance2(pnt_df0) < pnt_db_min0.distance2(pnt_df0)) {
+            //switch the edge s
+            db_min = m_gmap.alpha<1>(db_min);
+        }
+
+        //we copy the face attribute
+        Dart3 d_opp_face = m_gmap.alpha<2, 1, 0, 1, 2>(db_min);
+        if (was_sewed[df]){
+            m_gmap.sew<3>(d_opp_face,prev_3_dart[df]);
+        }
+        else {
+            m_gmap.attribute<2>(d_opp_face)->info().geom_dim = f->info().geom_dim;
+            m_gmap.attribute<2>(d_opp_face)->info().geom_id = f->info().geom_id;
+        }
+        m_gmap.sew<3>(df, db_min);
+        m_gmap.attribute<2>(df)->info().geom_dim = 3;
+        m_gmap.attribute<2>(df)->info().geom_id = NullID;
+
+        //after sewing, we change classification info
+        Dart3 d = df;
+        do {
+            auto att_node_d = m_gmap.attribute<0>(d);
+            auto att_edge_d = m_gmap.attribute<1>(d);
+
+            if (!m_gmap.is_marked(d, mark_already_merged_node)) {
+                m_gmap.mark_cell<0>(d, mark_already_merged_node);
+
+                //the opposite node keep the previous embedding
+                Dart3 d_opp = m_gmap.alpha<3, 2, 1, 0, 1, 2>(d);
+                m_gmap.attribute<0>(d_opp)->info().geom_id = att_node_d->info().geom_id;
+                m_gmap.attribute<0>(d_opp)->info().geom_dim = att_node_d->info().geom_dim;
+
+                //the current node is embedded onto the detected geom feature
+                auto [tdim, tid, gdim, gid] = pillow_node_data[d];
+                m_gmap.attribute<0>(d)->info().geom_dim = gdim;
+                m_gmap.attribute<0>(d)->info().geom_id = gid;
+
+                //the edge connected the two nodes is classified onto the same feature
+                Dart3 d_edge = m_gmap.alpha<3, 2, 1>(d);
+                m_gmap.attribute<1>(d_edge)->info().geom_dim = gdim;
+                m_gmap.attribute<1>(d_edge)->info().geom_id = gid;
+            }
+
+
+            if (m_gmap.is_marked(d,mark_already_merged_edge))
+            {
+                //means the corresponding block must be 3-sewed to another block in the inserted sheet
+                //From d, we lock for a blue dart in the edge orbit
+                Dart3 d3 = m_gmap.alpha<2>(d);
+                bool found = false;
+                do {
+                    if (m_gmap.is_marked(d3, mark_blue_side)) {
+                        found = true;
+                    } else {
+                        d3 = m_gmap.alpha<3, 2>(d3);
+                    }
+                } while (!found);
+                 m_gmap.sew<3>(m_gmap.alpha<3, 2>(d), m_gmap.alpha<3, 2>(d3));
+            }
+            else
+            {
+                m_gmap.mark_cell<1>(d, mark_already_merged_edge);
+                auto [e_geom_dim, e_geom_id] = pillow_edge_data[d];
+
+                //the opposite edge keep the previous embedding
+                Dart3 d_opp = m_gmap.alpha<3, 2, 1, 0, 1, 2>(d);
+                m_gmap.attribute<1>(d_opp)->info().geom_id = att_edge_d->info().geom_id;
+                m_gmap.attribute<1>(d_opp)->info().geom_dim = att_edge_d->info().geom_dim;
+
+                //the current edge is embedded onto the detected geom feature
+                // std::cout<<"Edge "<<m_gmap.attribute<1>(d)->info().topo_id<<" on: ("<<e_geom_dim<<", "<<e_geom_id<<")"<<std::endl;
+                m_gmap.attribute<1>(d)->info().geom_dim = e_geom_dim;
+                m_gmap.attribute<1>(d)->info().geom_id = e_geom_id;
+
+                //the face connected the two edge is classified onto the same feature
+                Dart3 d_face = m_gmap.alpha<3, 2>(d);
+                m_gmap.attribute<2>(d_face)->info().geom_dim = e_geom_dim;
+                m_gmap.attribute<2>(d_face)->info().geom_id = e_geom_id;
+            }
+            d = m_gmap.alpha<0, 1>(d);
+        } while (d != df);
+    }
+
+
+    //-------------------------------------------------------
+    //clean marks
+
+    m_gmap.unmark_all(mark_face);
+    m_gmap.unmark_all(mark_blue_side);
+    m_gmap.unmark_all(mark_red_side);
+    m_gmap.unmark_all(mark_already_merged_node);
+    m_gmap.unmark_all(mark_already_merged_edge);
+
+    m_gmap.free_mark(mark_face);
+    m_gmap.free_mark(mark_blue_side);
+    m_gmap.free_mark(mark_red_side);
+    m_gmap.free_mark(mark_already_merged_node);
+    m_gmap.free_mark(mark_already_merged_edge);
+ /*   std::cout << "============== Check final  =====================" << std::endl;
+    for (auto it = m_gmap.attributes<0>().begin(), itend = m_gmap.attributes<0>().end(); it != itend; ++it) {
+        std::cout << "Node " << it->info().topo_id << " geom info (" << it->info().geom_dim << ", "
+                  << it->info().geom_id << ")" << std::endl;
+    }
+    for (auto it = m_gmap.attributes<1>().begin(), itend = m_gmap.attributes<1>().end(); it != itend; ++it) {
+        std::cout << "Edge " << it->info().topo_id << " geom info (" << it->info().geom_dim << ", "
+                  << it->info().geom_id << ")" << std::endl;
+    }
+    std::cout << "=================================================" << std::endl;
+   */
+ return true;
+}
+
+/*----------------------------------------------------------------------------*/
+void CurvedBlocking::smooth(const int ANbIterations) {
+    for (auto i = 0; i < ANbIterations; i++) {
+        smooth_curves(1);
+        smooth_surfaces(1);
+        smooth_volumes(1);
+    }
+}
+
+/*----------------------------------------------------------------------------*/
+void CurvedBlocking::smooth_curves(const int ANbIterations) {
+    //We traverse all the nodes of the block structure and we keep in mind, those
+    //that are on curves
+    std::vector<Node> to_smooth;
+    for (auto it = m_gmap.attributes<0>().begin(), itend = m_gmap.attributes<0>().end(); it != itend; ++it) {
+        if (it->info().geom_dim == 1) {
+            //node on a curve
+            to_smooth.push_back(it);
+        }
+    }
+    for (auto n: to_smooth) {
+        //We get the location of each adjacent node connected through a 1-classified edge
+        Dart3 d = n->dart();
+        math::Point p = n->info().point;
+        math::Point deviation(0, 0, 0);
+        auto ball_size = 0;
+        //We get one dart per 1-cell adjacent to the 0-cell that contains d
+        for (auto it = m_gmap.one_dart_per_incident_cell<1, 0>(d).begin(),
+                     itend = m_gmap.one_dart_per_incident_cell<1, 0>(d).end(); it != itend; ++it) {
+            Edge e = m_gmap.attribute<1>(it);
+            if (e->info().geom_dim == 1) {
+                //we keep the opposite node
+                Dart3 d_opp = m_gmap.alpha<0>(it);
+                deviation = deviation + m_gmap.attribute<0>(d_opp)->info().point;
+                ball_size++;
+            }
+        }
+        if (ball_size != 0) {
+            //we mode n
+            math::Point p_new = 1.0 / (double) ball_size * deviation;
+            p = 0.5 * p + 0.5 * p_new;
+            move_node(n, p);
+        }
+    }
+}
+
+/*----------------------------------------------------------------------------*/
+void CurvedBlocking::smooth_surfaces(const int ANbIterations) {
+    //We traverse all the nodes of the block structure and we keep in mind, those
+    //that are on surfaces
+    std::vector<Node> to_smooth;
+    for (auto it = m_gmap.attributes<0>().begin(), itend = m_gmap.attributes<0>().end(); it != itend; ++it) {
+        if (it->info().geom_dim == 2) {
+            //node on a surface
+            to_smooth.push_back(it);
+        }
+    }
+    for (auto n: to_smooth) {
+        //We get the location of each adjacent node connected through a 2-classified edge
+        Dart3 d = n->dart();
+        math::Point p = n->info().point;
+        math::Point deviation(0, 0, 0);
+        auto ball_size = 0;
+        //We get one dart per 1-cell adjacent to the 0-cell that contains d
+        for (auto it = m_gmap.one_dart_per_incident_cell<1, 0>(d).begin(),
+                     itend = m_gmap.one_dart_per_incident_cell<1, 0>(d).end(); it != itend; ++it) {
+            Edge e = m_gmap.attribute<1>(it);
+            if (e->info().geom_dim == 2) {
+                //we keep the opposite node
+                Dart3 d_opp = m_gmap.alpha<0>(it);
+                deviation = deviation + m_gmap.attribute<0>(d_opp)->info().point;
+                ball_size++;
+            }
+        }
+        if (ball_size != 0) {
+            //we mode n
+            math::Point p_new = 1.0 / (double) ball_size * deviation;
+            p = 0.5 * p + 0.5 * p_new;
+            move_node(n, p);
+        }
+    }
+}
+
+/*----------------------------------------------------------------------------*/
+void CurvedBlocking::smooth_volumes(const int ANbIterations) {
+    //We traverse all the nodes of the block structure and we keep in mind, those
+    //that are in volume
+    std::vector<Node> to_smooth;
+    for (auto it = m_gmap.attributes<0>().begin(), itend = m_gmap.attributes<0>().end(); it != itend; ++it) {
+        if (it->info().geom_dim == 3) {
+            //node on a surface
+            to_smooth.push_back(it);
+        }
+    }
+    for (auto n: to_smooth) {
+        //We get the location of each adjacent node connected through a 2-classified edge
+        Dart3 d = n->dart();
+        math::Point p = n->info().point;
+        math::Point deviation(0, 0, 0);
+        auto ball_size = 0;
+        //We get one dart per 1-cell adjacent to the 0-cell that contains d
+        for (auto it = m_gmap.one_dart_per_incident_cell<1, 0>(d).begin(),
+                     itend = m_gmap.one_dart_per_incident_cell<1, 0>(d).end(); it != itend; ++it) {
+            Edge e = m_gmap.attribute<1>(it);
+            if (e->info().geom_dim == 3) {
+                //we keep the opposite node
+                Dart3 d_opp = m_gmap.alpha<0>(it);
+                deviation = deviation + m_gmap.attribute<0>(d_opp)->info().point;
+                ball_size++;
+            }
+        }
+        if (ball_size != 0) {
+            //we mode n
+            math::Point p_new = 1.0 / (double) ball_size * deviation;
+            p = 0.5 * p + 0.5 * p_new;
+            move_node(n, p);
+        }
+    }
+}
+
+/*----------------------------------------------------------------------------*/
+bool
 CurvedBlocking::collapse_chord(const Face AF, const Node AN1, const Node AN2) {
     //first we check that AN1 and AN2 belongs to AF and are opposite in AF
     Dart3 dart_f = AF->dart();
@@ -1010,16 +1653,16 @@ CurvedBlocking::collapse_chord(const Face AF, const Node AN1, const Node AN2) {
             m_gmap.darts_of_orbit<1, 2, 3>(dart_n2).end()); it != itend; ++it) {
         all_darts_n2.push_back(it);
     }
-        //We traverse all the darts of the face
+    //We traverse all the darts of the face
     for (GMap3::Dart_of_orbit_range<0, 1, 3>::iterator it(m_gmap.darts_of_orbit<0, 1, 3>(dart_f).begin()), itend(
             m_gmap.darts_of_orbit<0, 1, 3>(dart_f).end()); it != itend;
          ++it) {
         //Now we go through the dart of the current node
-        for(auto d:all_darts_n1) {
+        for (auto d: all_darts_n1) {
             if (it == d)
                 found_n1 = true;
         }
-        for(auto d:all_darts_n2) {
+        for (auto d: all_darts_n2) {
             if (it == d)
                 found_n2 = true;
         }
@@ -1029,8 +1672,8 @@ CurvedBlocking::collapse_chord(const Face AF, const Node AN1, const Node AN2) {
 
     // Are n1 and n2 opposite in the face ?
     bool n1_is_n2_opposite = false;
-    for(auto d2:all_darts_n2) {
-        for(auto d1:all_darts_n1) {
+    for (auto d2: all_darts_n2) {
+        for (auto d1: all_darts_n1) {
             if (m_gmap.alpha<0, 1, 0>(d1) == d2)
                 n1_is_n2_opposite = true;
         }
@@ -1041,50 +1684,48 @@ CurvedBlocking::collapse_chord(const Face AF, const Node AN1, const Node AN2) {
     // We need the pair of nodes to collapse in each face. To do that, we iteratively work in each
     // face traversed by the sheet
     std::vector<Dart3> chord_darts, chord_darts_opp;
-    get_all_chord_darts(AF,chord_darts);
-    for(auto d:chord_darts){
-        chord_darts_opp.push_back(m_gmap.alpha<0,1,0>(d));
+    get_all_chord_darts(AF, chord_darts);
+    for (auto d: chord_darts) {
+        chord_darts_opp.push_back(m_gmap.alpha<0, 1, 0>(d));
     }
 
     //Before going further, we check that all the pair of opposite nodes can be merged (geometric conditions)
-    for(auto i=0; i<chord_darts.size();i++) {
+    for (auto i = 0; i < chord_darts.size(); i++) {
         Node ni = m_gmap.attribute<0>(chord_darts[i]);
         Node nj = m_gmap.attribute<0>(chord_darts_opp[i]);
-        if(ni->info().geom_dim==0 && nj->info().geom_dim==0){
+        if (ni->info().geom_dim == 0 && nj->info().geom_dim == 0) {
             //two nodes can not be merged together
             return false;
-        }
-        else if(ni->info().geom_dim==1 && nj->info().geom_dim==1 && ni->info().geom_id!=nj->info().geom_id){
+        } else if (ni->info().geom_dim == 1 && nj->info().geom_dim == 1 && ni->info().geom_id != nj->info().geom_id) {
             //two nodes on different curves cannot be merged
             return false;
-        }
-        else if(ni->info().geom_dim==2 && nj->info().geom_dim==2 && ni->info().geom_id!=nj->info().geom_id){
+        } else if (ni->info().geom_dim == 2 && nj->info().geom_dim == 2 && ni->info().geom_id != nj->info().geom_id) {
             //two nodes on different surfaces cannot be merged
             return false;
         }
     }
     //Now we have pairs of darts that belongs to opposite nodes that must be collapsed. We get nodes of adjacent faces
     //to 3-sew
-    std::vector<std::pair<Dart3,Dart3> > to_sew;
-    for(auto i=0; i<chord_darts.size();i++){
+    std::vector<std::pair<Dart3, Dart3> > to_sew;
+    for (auto i = 0; i < chord_darts.size(); i++) {
         Dart3 di = chord_darts[i];
         Dart3 dj = chord_darts_opp[i];
-        to_sew.push_back(std::make_pair(m_gmap.alpha<2,3>(di),m_gmap.alpha<2,3>(dj)));
-        to_sew.push_back(std::make_pair(m_gmap.alpha<1,2,3>(di),m_gmap.alpha<1,2,3>(dj)));
-        if(!m_gmap.is_free<3>(di)){
-            to_sew.push_back(std::make_pair(m_gmap.alpha<3,2,3>(di),m_gmap.alpha<3,2,3>(dj)));
-            to_sew.push_back(std::make_pair(m_gmap.alpha<3,1,2,3>(di),m_gmap.alpha<3,1,2,3>(dj)));
+        to_sew.push_back(std::make_pair(m_gmap.alpha<2, 3>(di), m_gmap.alpha<2, 3>(dj)));
+        to_sew.push_back(std::make_pair(m_gmap.alpha<1, 2, 3>(di), m_gmap.alpha<1, 2, 3>(dj)));
+        if (!m_gmap.is_free<3>(di)) {
+            to_sew.push_back(std::make_pair(m_gmap.alpha<3, 2, 3>(di), m_gmap.alpha<3, 2, 3>(dj)));
+            to_sew.push_back(std::make_pair(m_gmap.alpha<3, 1, 2, 3>(di), m_gmap.alpha<3, 1, 2, 3>(dj)));
         }
     }
     //We remove chord blocks
     std::vector<Block> chord_blocks = get_all_chord_blocks(AF);
-    for(auto b:chord_blocks) {
+    for (auto b: chord_blocks) {
         remove_block(b);
     }
     //and now, we fill the void by sewing darts
-    for(auto dd : to_sew){
-        if (m_gmap.is_free<3>(dd.first)){
-            m_gmap.sew<3>(dd.first,dd.second);
+    for (auto dd: to_sew) {
+        if (m_gmap.is_free<3>(dd.first)) {
+            m_gmap.sew<3>(dd.first, dd.second);
         }
     }
     return true;

--- a/blocking/tst/CurvedBlockingTestSuite.h
+++ b/blocking/tst/CurvedBlockingTestSuite.h
@@ -31,7 +31,64 @@ setUp(gmds::cad::FACManager &AGeomManager)
 
 	AGeomManager.initFrom3DMesh(&m_vol);
 }
-
+/*----------------------------------------------------------------------------*/
+std::tuple<int,int,int,int> get_node_statistics(gmds::blocking::CurvedBlocking& ABlocking){
+    auto nb_on_vertex=0;
+    auto nb_on_curve=0;
+    auto nb_on_surface=0;
+    auto nb_in_volume=0;
+    std::vector<gmds::blocking::CurvedBlocking::Node> all_nodes = ABlocking.get_all_nodes();
+    for(auto n:all_nodes){
+        if(n->info().geom_dim==0)
+            nb_on_vertex++;
+        else if(n->info().geom_dim==1)
+            nb_on_curve++;
+        else if(n->info().geom_dim==2)
+            nb_on_surface++;
+        else if(n->info().geom_dim==3)
+            nb_in_volume++;
+    }
+    return std::make_tuple(nb_on_vertex,nb_on_curve,nb_on_surface,nb_in_volume);
+}
+/*----------------------------------------------------------------------------*/
+std::tuple<int,int,int> get_edge_statistics(gmds::blocking::CurvedBlocking& ABlocking){
+    auto nb_on_curve=0;
+    auto nb_on_surface=0;
+    auto nb_in_volume=0;
+    std::vector<gmds::blocking::CurvedBlocking::Edge> all_edges = ABlocking.get_all_edges();
+    for(auto e:all_edges){
+        if(e->info().geom_dim==1)
+            nb_on_curve++;
+        else if(e->info().geom_dim==2)
+            nb_on_surface++;
+        else if(e->info().geom_dim==3)
+            nb_in_volume++;
+    }
+    return std::make_tuple(nb_on_curve,nb_on_surface,nb_in_volume);
+}
+/*----------------------------------------------------------------------------*/
+std::tuple<int,int> get_face_statistics(gmds::blocking::CurvedBlocking& ABlocking){
+    auto nb_on_surface=0;
+    auto nb_in_volume=0;
+    std::vector<gmds::blocking::CurvedBlocking::Face> all_faces = ABlocking.get_all_faces();
+    for(auto f:all_faces){
+        if(f->info().geom_dim==2)
+            nb_on_surface++;
+        else if(f->info().geom_dim==3)
+            nb_in_volume++;
+    }
+    return std::make_tuple(nb_on_surface,nb_in_volume);
+}
+/*----------------------------------------------------------------------------*/
+void export_vtk(gmds::blocking::CurvedBlocking& ABlocking, int AModel, const std::string& AFileName){
+    gmds::Mesh m_out(gmds::MeshModel(gmds::DIM3 | gmds::N | gmds::E | gmds::F | gmds::R | gmds::E2N | gmds::F2N | gmds::R2N));
+    ABlocking.convert_to_mesh(m_out);
+    gmds::IGMeshIOService ioService(&m_out);
+    gmds::VTKWriter writer(&ioService);
+    writer.setCellOptions(AModel);
+    writer.setDataOptions(AModel);
+    writer.write(AFileName);
+}
 /*----------------------------------------------------------------------------*/
 TEST(CurvedBlockingTestSuite, global_cell_accessors)
 {
@@ -121,8 +178,8 @@ TEST(CurvedBlockingTestSuite, single_block)
 	gmds::math::Point p112(1, 1, 2);
 	gmds::math::Point p102(1, 0, 2);
 	auto b = bl.create_block(p000, p010, p110, p100, p001, p011, p111, p101);
-	ASSERT_EQ(b->info().geom_dim, 4);
-	ASSERT_EQ(b->info().geom_id, -1);
+	ASSERT_EQ(b->info().geom_dim, 3);
+	ASSERT_EQ(b->info().geom_id, gmds::NullID);
 	auto fs = bl.get_faces_of_block(b);
 	ASSERT_EQ(fs.size(), 6);
 	auto block_center = bl.get_center_of_block(b);
@@ -429,12 +486,10 @@ TEST(CurvedBlockingTestSuite, test_chord_collapse)
     gmds::Mesh m(gmds::MeshModel(gmds::DIM3|gmds::N|gmds::R|gmds::R2N));
 
     gmds::GridBuilder gb(&m,3);
-
     gb.execute(4,1.0, 4, 1.0, 4, 1.0);
-
     bl.init_from_mesh(m);
 
-    std::vector<gmds::blocking::Dart3> darts;
+
     std::vector<gmds::blocking::CurvedBlocking::Face> bl_faces = bl.get_all_faces();
 
     ASSERT_EQ(bl.get_nb_cells<3>(),27);
@@ -464,5 +519,613 @@ TEST(CurvedBlockingTestSuite, test_chord_collapse)
     writer.setCellOptions(gmds::N | gmds::F);
     writer.setDataOptions(gmds::N |gmds::F );
     writer.write("collapse.vtk");
+}
+/*----------------------------------------------------------------------------*/
+TEST(CurvedBlockingTestSuite, test_validate_pillow)
+{
+    gmds::cad::FACManager geom_model;
+    setUp(geom_model);
+    gmds::blocking::CurvedBlocking bl(&geom_model, true);
+    gmds::blocking::CurvedBlockingClassifier cl(&bl);
+    cl.classify();
 
+    gmds::cad::GeomVolume* v = geom_model.getVolumes()[0];
+
+    auto [x_min,y_min,z_min,x_max,y_max,z_max] = v->BBox();
+
+    std::vector<std::vector<gmds::blocking::CurvedBlocking::Edge>> edges = bl.get_all_sheet_edge_sets();
+    for(auto par_edges_i:edges) {
+        bl.cut_sheet(par_edges_i[0]);
+    }
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),8);
+    std::vector<gmds::blocking::CurvedBlocking::Face> all_faces = bl.get_all_faces();
+    std::vector<gmds::blocking::CurvedBlocking::Face> surf;
+    //We pick all the boundary faces
+    for(auto f:all_faces){
+        if(f->info().geom_dim==2){
+            surf.push_back(f);
+        }
+    }
+    ASSERT_TRUE(bl.validate_pillowing_surface(surf));
+
+    surf.clear();
+    //We pick a full boundary surface on coord X=5.0
+    for(auto f:all_faces){
+        gmds::math::Point ci = bl.get_center_of_face(f);
+        if(fabs(ci.X()-5)<0.1){
+            surf.push_back(f);
+        }
+    }
+    ASSERT_TRUE(bl.validate_pillowing_surface(surf));
+    surf.pop_back();
+    ASSERT_FALSE(bl.validate_pillowing_surface(surf));
+    surf.pop_back();
+    ASSERT_FALSE(bl.validate_pillowing_surface(surf));
+    surf.pop_back();
+    ASSERT_FALSE(bl.validate_pillowing_surface(surf));
+}
+
+/*----------------------------------------------------------------------------*/
+TEST(CurvedBlockingTestSuite, test_pillow)
+{
+    gmds::cad::FACManager geom_model;
+    setUp(geom_model);
+    gmds::blocking::CurvedBlocking bl(&geom_model, true);
+    gmds::blocking::CurvedBlockingClassifier cl(&bl);
+    cl.classify();
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),1);
+    std::vector<gmds::blocking::CurvedBlocking::Face> all_faces = bl.get_all_faces();
+    std::vector<gmds::blocking::CurvedBlocking::Face> surf;
+
+    surf.clear();
+    //We pick a full boundary surface on coord X=5.0
+    for(auto f:all_faces){
+        gmds::math::Point ci = bl.get_center_of_face(f);
+        if(fabs(ci.X()-5)<0.1){
+            surf.push_back(f);
+        }
+    }
+    ASSERT_TRUE(bl.pillow(surf));
+
+    bl.smooth(1);
+//    export_vtk(bl,gmds::N | gmds::F, "pillow_1_surf.vtk");
+    ASSERT_EQ(bl.get_nb_cells<3>(),2);
+    auto [nb_nodes_on_vertex,nb_nodes_on_curve,nb_nodes_on_surface,nb_nodes_in_volume] = get_node_statistics(bl);
+    ASSERT_EQ(nb_nodes_on_vertex, 8);
+    ASSERT_EQ(nb_nodes_on_curve, 4);
+    ASSERT_EQ(nb_nodes_on_surface, 0);
+    ASSERT_EQ(nb_nodes_in_volume, 0);
+    auto [nb_edges_on_curve,nb_edges_on_surface,nb_edges_in_volume] = get_edge_statistics(bl);
+    ASSERT_EQ(nb_edges_on_curve, 16);
+    ASSERT_EQ(nb_edges_on_surface, 4);
+    ASSERT_EQ(nb_edges_in_volume, 0);
+    auto [nb_faces_on_surface,nb_faces_in_volume] = get_face_statistics(bl);
+    ASSERT_EQ(nb_faces_on_surface, 10);
+    ASSERT_EQ(nb_faces_in_volume, 1);
+}
+/*----------------------------------------------------------------------------*/
+TEST(CurvedBlockingTestSuite, test_pillow_2)
+{
+    gmds::cad::FACManager geom_model;
+    setUp(geom_model);
+    gmds::blocking::CurvedBlocking bl(&geom_model, true);
+    gmds::blocking::CurvedBlockingClassifier cl(&bl);
+    cl.classify();
+
+    std::vector<std::vector<gmds::blocking::CurvedBlocking::Edge>> edges = bl.get_all_sheet_edge_sets();
+    for(auto par_edges_i:edges) {
+        bl.cut_sheet(par_edges_i[0]);
+    }
+    ASSERT_EQ(bl.get_nb_cells<3>(),8);
+    std::vector<gmds::blocking::CurvedBlocking::Face> all_faces = bl.get_all_faces();
+    std::vector<gmds::blocking::CurvedBlocking::Face> surf;
+    surf.clear();
+    //We pick a full boundary surface on coord X=5.0 and Y=5.0
+    for(auto f:all_faces){
+        gmds::math::Point ci = bl.get_center_of_face(f);
+        if(fabs(ci.X()-5)<0.1){
+            surf.push_back(f);
+        }
+        else if(fabs(ci.Y()-5)<0.1){
+            surf.push_back(f);
+        }
+    }
+    ASSERT_TRUE(bl.pillow(surf));
+
+    bl.smooth(10);
+
+    //export_vtk(bl,gmds::N | gmds::F, "pillow_2_surf.vtk");
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),16);
+    auto [nb_nodes_on_vertex,nb_nodes_on_curve,nb_nodes_on_surface,nb_nodes_in_volume] = get_node_statistics(bl);
+    ASSERT_EQ(nb_nodes_on_vertex, 8);
+    ASSERT_EQ(nb_nodes_on_curve, 16);
+    ASSERT_EQ(nb_nodes_on_surface, 14);
+    ASSERT_EQ(nb_nodes_in_volume, 4);
+    auto [nb_edges_on_curve,nb_edges_on_surface,nb_edges_in_volume] = get_edge_statistics(bl);
+    ASSERT_EQ(nb_edges_on_curve, 28);
+    ASSERT_EQ(nb_edges_on_surface, 44);
+    ASSERT_EQ(nb_edges_in_volume, 19);
+    auto [nb_faces_on_surface,nb_faces_in_volume] = get_face_statistics(bl);
+    ASSERT_EQ(nb_faces_on_surface, 36);
+    ASSERT_EQ(nb_faces_in_volume, 30);
+}
+
+/*----------------------------------------------------------------------------*/
+TEST(CurvedBlockingTestSuite, test_pillow_3)
+{
+    gmds::cad::FACManager geom_model;
+    setUp(geom_model);
+    gmds::blocking::CurvedBlocking bl(&geom_model, true);
+    gmds::blocking::CurvedBlockingClassifier cl(&bl);
+    cl.classify();
+
+    std::vector<gmds::blocking::CurvedBlocking::Face> all_faces = bl.get_all_faces();
+    std::vector<gmds::blocking::CurvedBlocking::Face> surf;
+
+    surf.clear();
+    //We pick a full boundary surface on coord X=5.0 and Y=5.0
+    for(auto f:all_faces){
+        gmds::math::Point ci = bl.get_center_of_face(f);
+        if(fabs(ci.X()-5)<0.1){
+            surf.push_back(f);
+        }
+        else if(fabs(ci.Y()-5)<0.1){
+            surf.push_back(f);
+        }
+    }
+    ASSERT_TRUE(bl.pillow(surf));
+
+    bl.smooth(10);
+
+    //export_vtk(bl,gmds::N | gmds::F, "pillow_3_surf.vtk");
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),3);
+    auto [nb_nodes_on_vertex,nb_nodes_on_curve,nb_nodes_on_surface,nb_nodes_in_volume] = get_node_statistics(bl);
+    ASSERT_EQ(nb_nodes_on_vertex, 8);
+    ASSERT_EQ(nb_nodes_on_curve, 4);
+    ASSERT_EQ(nb_nodes_on_surface, 2);
+    ASSERT_EQ(nb_nodes_in_volume, 0);
+    auto [nb_edges_on_curve,nb_edges_on_surface,nb_edges_in_volume] = get_edge_statistics(bl);
+    ASSERT_EQ(nb_edges_on_curve, 16);
+    ASSERT_EQ(nb_edges_on_surface, 8);
+    ASSERT_EQ(nb_edges_in_volume, 1);
+    auto [nb_faces_on_surface,nb_faces_in_volume] = get_face_statistics(bl);
+    ASSERT_EQ(nb_faces_on_surface, 12);
+    ASSERT_EQ(nb_faces_in_volume, 3);}
+
+/*----------------------------------------------------------------------------*/
+TEST(CurvedBlockingTestSuite, test_pillow_4)
+{
+    gmds::cad::FACManager geom_model;
+    setUp(geom_model);
+    gmds::blocking::CurvedBlocking bl(&geom_model, true);
+    gmds::blocking::CurvedBlockingClassifier cl(&bl);
+    cl.classify();
+
+    std::vector<gmds::blocking::CurvedBlocking::Face> all_faces = bl.get_all_faces();
+    std::vector<gmds::blocking::CurvedBlocking::Face> surf;
+
+    surf.clear();
+    //We pick a full boundary surface on coord X=5.0 and Y=5.0
+    for(auto f:all_faces){
+        gmds::math::Point ci = bl.get_center_of_face(f);
+        if(fabs(ci.X()-5)<0.1){
+            surf.push_back(f);
+        }
+        else if(fabs(ci.Y()-5)<0.1){
+            surf.push_back(f);
+        }
+        else if(fabs(ci.Z()-5)<0.1){
+            surf.push_back(f);
+        }
+    }
+    ASSERT_TRUE(bl.pillow(surf));
+
+    bl.smooth(10);
+    //export_vtk(bl,gmds::N | gmds::F, "pillow_4_surf.vtk");
+    ASSERT_EQ(bl.get_nb_cells<3>(),4);
+    auto [nb_nodes_on_vertex,nb_nodes_on_curve,nb_nodes_on_surface,nb_nodes_in_volume] = get_node_statistics(bl);
+    ASSERT_EQ(nb_nodes_on_vertex, 8);
+    ASSERT_EQ(nb_nodes_on_curve, 3);
+    ASSERT_EQ(nb_nodes_on_surface, 3);
+    ASSERT_EQ(nb_nodes_in_volume, 1);
+    auto [nb_edges_on_curve,nb_edges_on_surface,nb_edges_in_volume] = get_edge_statistics(bl);
+    ASSERT_EQ(nb_edges_on_curve, 15);
+    ASSERT_EQ(nb_edges_on_surface, 9);
+    ASSERT_EQ(nb_edges_in_volume, 4);
+    auto [nb_faces_on_surface,nb_faces_in_volume] = get_face_statistics(bl);
+    ASSERT_EQ(nb_faces_on_surface, 12);
+    ASSERT_EQ(nb_faces_in_volume, 6);
+}
+
+/*----------------------------------------------------------------------------*/
+TEST(CurvedBlockingTestSuite, test_pillow_5)
+{
+    gmds::cad::FACManager geom_model;
+    setUp(geom_model);
+    gmds::blocking::CurvedBlocking bl(&geom_model, true);
+    gmds::blocking::CurvedBlockingClassifier cl(&bl);
+    cl.classify();
+
+    std::vector<gmds::blocking::CurvedBlocking::Face> all_faces = bl.get_all_faces();
+    std::vector<gmds::blocking::CurvedBlocking::Face> surf;
+
+    surf.clear();
+    //We pick a full boundary surface on coord X=5.0 and Y=5.0
+    for(auto f:all_faces){
+        gmds::math::Point ci = bl.get_center_of_face(f);
+        if(fabs(ci.X()-5)<0.1){
+            surf.push_back(f);
+        }
+        else if(fabs(ci.Y()-5)<0.1){
+            surf.push_back(f);
+        }
+        else if(fabs(ci.Z()-5)<0.1){
+            surf.push_back(f);
+        }
+        else if(fabs(ci.Z()+5)<0.1){
+            surf.push_back(f);
+        }
+    }
+    ASSERT_TRUE(bl.pillow(surf));
+
+    bl.smooth(10);
+    //export_vtk(bl,gmds::N | gmds::F, "pillow_5_surf.vtk");
+    ASSERT_EQ(bl.get_nb_cells<3>(),5);
+    auto [nb_nodes_on_vertex,nb_nodes_on_curve,nb_nodes_on_surface,nb_nodes_in_volume] = get_node_statistics(bl);
+    ASSERT_EQ(nb_nodes_on_vertex, 8);
+    ASSERT_EQ(nb_nodes_on_curve, 2);
+    ASSERT_EQ(nb_nodes_on_surface, 4);
+    ASSERT_EQ(nb_nodes_in_volume, 2);
+    auto [nb_edges_on_curve,nb_edges_on_surface,nb_edges_in_volume] = get_edge_statistics(bl);
+    ASSERT_EQ(nb_edges_on_curve, 14);
+    ASSERT_EQ(nb_edges_on_surface, 10);
+    ASSERT_EQ(nb_edges_in_volume, 7);
+    auto [nb_faces_on_surface,nb_faces_in_volume] = get_face_statistics(bl);
+    ASSERT_EQ(nb_faces_on_surface, 12);
+    ASSERT_EQ(nb_faces_in_volume, 9);
+}
+/*----------------------------------------------------------------------------*/
+TEST(CurvedBlockingTestSuite, test_pillow_6)
+{
+    gmds::cad::FACManager geom_model;
+    setUp(geom_model);
+    gmds::blocking::CurvedBlocking bl(&geom_model, true);
+    gmds::blocking::CurvedBlockingClassifier cl(&bl);
+    cl.classify();
+
+    std::vector<gmds::blocking::CurvedBlocking::Face> all_faces = bl.get_all_faces();
+    std::vector<gmds::blocking::CurvedBlocking::Face> surf;
+
+    surf.clear();
+    //We pick a full boundary surface on coord X=5.0 and Y=5.0
+    for(auto f:all_faces){
+        gmds::math::Point ci = bl.get_center_of_face(f);
+        if(fabs(ci.X()-5)<0.1){
+            surf.push_back(f);
+        }
+        else if(fabs(ci.Y()-5)<0.1){
+            surf.push_back(f);
+        }
+        else if(fabs(ci.Y()+5)<0.1){
+            surf.push_back(f);
+        }
+        else if(fabs(ci.Z()-5)<0.1){
+            surf.push_back(f);
+        }
+        else if(fabs(ci.Z()+5)<0.1){
+            surf.push_back(f);
+        }
+    }
+    ASSERT_TRUE(bl.pillow(surf));
+
+    bl.smooth(10);
+
+    //export_vtk(bl,gmds::N | gmds::F, "pillow_6_surf.vtk");
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),6);
+    auto [nb_nodes_on_vertex,nb_nodes_on_curve,nb_nodes_on_surface,nb_nodes_in_volume] = get_node_statistics(bl);
+    ASSERT_EQ(nb_nodes_on_vertex, 8);
+    ASSERT_EQ(nb_nodes_on_curve, 0);
+    ASSERT_EQ(nb_nodes_on_surface, 4);
+    ASSERT_EQ(nb_nodes_in_volume, 4);
+    auto [nb_edges_on_curve,nb_edges_on_surface,nb_edges_in_volume] = get_edge_statistics(bl);
+    ASSERT_EQ(nb_edges_on_curve, 12);
+    ASSERT_EQ(nb_edges_on_surface, 8);
+    ASSERT_EQ(nb_edges_in_volume, 12);
+    auto [nb_faces_on_surface,nb_faces_in_volume] = get_face_statistics(bl);
+    ASSERT_EQ(nb_faces_on_surface, 10);
+    ASSERT_EQ(nb_faces_in_volume, 13);
+}
+/*----------------------------------------------------------------------------*/
+TEST(CurvedBlockingTestSuite, test_pillow_7)
+{
+    gmds::cad::FACManager geom_model;
+    setUp(geom_model);
+    gmds::blocking::CurvedBlocking bl(&geom_model, true);
+    gmds::blocking::CurvedBlockingClassifier cl(&bl);
+    cl.classify();
+
+    std::vector<gmds::blocking::CurvedBlocking::Face> all_faces = bl.get_all_faces();
+
+    ASSERT_TRUE(bl.pillow(all_faces));
+
+    bl.smooth(10);
+
+    //export_vtk(bl,gmds::N | gmds::F, "pillow_7_surf.vtk");
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),7);
+    auto [nb_nodes_on_vertex,nb_nodes_on_curve,nb_nodes_on_surface,nb_nodes_in_volume] = get_node_statistics(bl);
+    ASSERT_EQ(nb_nodes_on_vertex, 8);
+    ASSERT_EQ(nb_nodes_on_curve, 0);
+    ASSERT_EQ(nb_nodes_on_surface, 0);
+    ASSERT_EQ(nb_nodes_in_volume, 8);
+    auto [nb_edges_on_curve,nb_edges_on_surface,nb_edges_in_volume] = get_edge_statistics(bl);
+    ASSERT_EQ(nb_edges_on_curve, 12);
+    ASSERT_EQ(nb_edges_on_surface, 0);
+    ASSERT_EQ(nb_edges_in_volume, 20);
+    auto [nb_faces_on_surface,nb_faces_in_volume] = get_face_statistics(bl);
+    ASSERT_EQ(nb_faces_on_surface, 6);
+    ASSERT_EQ(nb_faces_in_volume, 18);
+}
+/*----------------------------------------------------------------------------*/
+TEST(CurvedBlockingTestSuite, test_pillow_8)
+{
+    gmds::cad::FACManager geom_model;
+    setUp(geom_model);
+    gmds::blocking::CurvedBlocking bl(&geom_model, true);
+    gmds::blocking::CurvedBlockingClassifier cl(&bl);
+    cl.classify();
+
+    std::vector<std::vector<gmds::blocking::CurvedBlocking::Edge>> edges = bl.get_all_sheet_edge_sets();
+    for(auto par_edges_i:edges) {
+        bl.cut_sheet(par_edges_i[0]);
+    }
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),8);
+
+    std::vector<gmds::blocking::CurvedBlocking::Face> all_faces = bl.get_all_faces();
+    std::vector<gmds::blocking::CurvedBlocking::Face> surf;
+
+    surf.clear();
+    //We pick a full boundary surface on coord X=5.0
+    for(auto f:all_faces){
+        auto nb_adj = bl.get_blocks_of_face(f);
+        if(nb_adj.size()==1)
+            surf.push_back(f);
+    }
+    ASSERT_TRUE(bl.pillow(surf));
+
+    bl.smooth(10);
+
+    //export_vtk(bl,gmds::N | gmds::F, "pillow_8_surf.vtk");
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),32);
+    auto [nb_nodes_on_vertex,nb_nodes_on_curve,nb_nodes_on_surface,nb_nodes_in_volume] = get_node_statistics(bl);
+    ASSERT_EQ(nb_nodes_on_vertex, 8);
+    ASSERT_EQ(nb_nodes_on_curve, 12);
+    ASSERT_EQ(nb_nodes_on_surface, 6);
+    ASSERT_EQ(nb_nodes_in_volume, 27);
+    auto [nb_edges_on_curve,nb_edges_on_surface,nb_edges_in_volume] = get_edge_statistics(bl);
+    ASSERT_EQ(nb_edges_on_curve, 24);
+    ASSERT_EQ(nb_edges_on_surface, 24);
+    ASSERT_EQ(nb_edges_in_volume, 80);
+    auto [nb_faces_on_surface,nb_faces_in_volume] = get_face_statistics(bl);
+    ASSERT_EQ(nb_faces_on_surface, 24);
+    ASSERT_EQ(nb_faces_in_volume, 84);
+}
+/*----------------------------------------------------------------------------*/
+TEST(CurvedBlockingTestSuite, test_pillow_9)
+{
+    gmds::cad::FACManager geom_model;
+    setUp(geom_model);
+    gmds::blocking::CurvedBlocking bl(&geom_model, true);
+    gmds::blocking::CurvedBlockingClassifier cl(&bl);
+    cl.classify();
+
+    std::vector<std::vector<gmds::blocking::CurvedBlocking::Edge>> edges = bl.get_all_sheet_edge_sets();
+    for(auto par_edges_i:edges) {
+        bl.cut_sheet(par_edges_i[0]);
+    }
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),8);
+
+    std::vector<gmds::blocking::CurvedBlocking::Face> all_faces = bl.get_all_faces();
+    std::vector<gmds::blocking::CurvedBlocking::Face> surf;
+
+    surf.clear();
+    //We pick a full boundary surface on coord X=5.0 and Y=5.0
+    for(auto f:all_faces){
+        gmds::math::Point ci = bl.get_center_of_face(f);
+        if(fabs(ci.X()-5)<0.1){
+            surf.push_back(f);
+        }
+        else if(fabs(ci.Y()-5)<0.1){
+            surf.push_back(f);
+        }
+        else if(fabs(ci.Z()-5)<0.1){
+            surf.push_back(f);
+        }
+    }
+    ASSERT_TRUE(bl.pillow(surf));
+
+    bl.smooth(10);
+
+    //export_vtk(bl,gmds::N | gmds::F, "pillow_9_surf.vtk");
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),20);
+    auto [nb_nodes_on_vertex,nb_nodes_on_curve,nb_nodes_on_surface,nb_nodes_in_volume] = get_node_statistics(bl);
+    ASSERT_EQ(nb_nodes_on_vertex, 8);
+    ASSERT_EQ(nb_nodes_on_curve, 15);
+    ASSERT_EQ(nb_nodes_on_surface, 15);
+    ASSERT_EQ(nb_nodes_in_volume, 8);
+    auto [nb_edges_on_curve,nb_edges_on_surface,nb_edges_in_volume] = get_edge_statistics(bl);
+    ASSERT_EQ(nb_edges_on_curve, 27);
+    ASSERT_EQ(nb_edges_on_surface, 45);
+    ASSERT_EQ(nb_edges_in_volume, 31);
+    auto [nb_faces_on_surface,nb_faces_in_volume] = get_face_statistics(bl);
+    ASSERT_EQ(nb_faces_on_surface, 36);
+    ASSERT_EQ(nb_faces_in_volume, 42);
+}
+/*----------------------------------------------------------------------------*/
+TEST(CurvedBlockingTestSuite, test_pillow_10)
+{
+    gmds::cad::FACManager geom_model;
+    setUp(geom_model);
+    gmds::blocking::CurvedBlocking bl(&geom_model, true);
+    gmds::blocking::CurvedBlockingClassifier cl(&bl);
+    cl.classify();
+
+    std::vector<std::vector<gmds::blocking::CurvedBlocking::Edge>> edges = bl.get_all_sheet_edge_sets();
+    for(auto par_edges_i:edges) {
+        bl.cut_sheet(par_edges_i[0]);
+    }
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),8);
+
+    std::vector<gmds::blocking::CurvedBlocking::Face> all_faces = bl.get_all_faces();
+    std::vector<gmds::blocking::CurvedBlocking::Face> surf;
+
+    surf.clear();
+    //We pick an inner surface
+    for(auto f:all_faces){
+        gmds::math::Point ci = bl.get_center_of_face(f);
+        if(fabs(ci.X())<0.1){
+            surf.push_back(f);
+        }
+    }
+    ASSERT_EQ(surf.size(),4);
+
+    //export_vtk(bl,gmds::N | gmds::F, "pillow_10_surf_before.vtk");
+    ASSERT_TRUE(bl.pillow(surf));
+
+    bl.smooth(10);
+
+    export_vtk(bl,gmds::N | gmds::E, "pillow_10_surf.vtk");
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),12);
+    auto [nb_nodes_on_vertex,nb_nodes_on_curve,nb_nodes_on_surface,nb_nodes_in_volume] = get_node_statistics(bl);
+    ASSERT_EQ(nb_nodes_on_vertex, 8);
+    ASSERT_EQ(nb_nodes_on_curve, 16);
+    ASSERT_EQ(nb_nodes_on_surface, 10);
+    ASSERT_EQ(nb_nodes_in_volume, 2);
+    auto [nb_edges_on_curve,nb_edges_on_surface,nb_edges_in_volume] = get_edge_statistics(bl);
+    ASSERT_EQ(nb_edges_on_curve, 28);
+    ASSERT_EQ(nb_edges_on_surface, 36);
+    ASSERT_EQ(nb_edges_in_volume, 11);
+    auto [nb_faces_on_surface,nb_faces_in_volume] = get_face_statistics(bl);
+    ASSERT_EQ(nb_faces_on_surface, 32);
+    ASSERT_EQ(nb_faces_in_volume, 20);
+}
+
+/*----------------------------------------------------------------------------*/
+TEST(CurvedBlockingTestSuite, test_pillow_11)
+{
+    gmds::cad::FACManager geom_model;
+    setUp(geom_model);
+    gmds::blocking::CurvedBlocking bl(&geom_model, true);
+    gmds::blocking::CurvedBlockingClassifier cl(&bl);
+    cl.classify();
+
+    std::vector<std::vector<gmds::blocking::CurvedBlocking::Edge>> edges = bl.get_all_sheet_edge_sets();
+    for(auto par_edges_i:edges) {
+        bl.cut_sheet(par_edges_i[0]);
+    }
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),8);
+
+    std::vector<gmds::blocking::CurvedBlocking::Face> all_faces = bl.get_all_faces();
+    std::vector<gmds::blocking::CurvedBlocking::Face> surf;
+
+    surf.clear();
+    //We pick an inner surface
+    for(auto f:all_faces){
+        gmds::math::Point ci = bl.get_center_of_face(f);
+        if(fabs(ci.X())<0.1 && ci.Y()<0 && ci.Z()<0){
+            surf.push_back(f);
+        }
+        else if(ci.X() <0 && fabs(ci.Y())<0.1 && ci.Z()<0){
+            surf.push_back(f);
+        }
+        else if(ci.X()<0 && ci.Y()<0 && fabs(ci.Z())<0.1){
+            surf.push_back(f);
+        }
+    }
+    ASSERT_EQ(surf.size(),3);
+
+    ASSERT_TRUE(bl.pillow(surf));
+
+    bl.smooth(10);
+
+   // export_vtk(bl,gmds::N | gmds::E, "pillow_11_surf.vtk");
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),11);
+    auto [nb_nodes_on_vertex,nb_nodes_on_curve,nb_nodes_on_surface,nb_nodes_in_volume] = get_node_statistics(bl);
+    ASSERT_EQ(nb_nodes_on_vertex, 8);
+    ASSERT_EQ(nb_nodes_on_curve, 15);
+    ASSERT_EQ(nb_nodes_on_surface, 9);
+    ASSERT_EQ(nb_nodes_in_volume, 2);
+    auto [nb_edges_on_curve,nb_edges_on_surface,nb_edges_in_volume] = get_edge_statistics(bl);
+    ASSERT_EQ(nb_edges_on_curve, 27);
+    ASSERT_EQ(nb_edges_on_surface, 33);
+    ASSERT_EQ(nb_edges_in_volume, 10);
+    auto [nb_faces_on_surface,nb_faces_in_volume] = get_face_statistics(bl);
+    ASSERT_EQ(nb_faces_on_surface, 30);
+    ASSERT_EQ(nb_faces_in_volume, 18);
+}
+
+/*----------------------------------------------------------------------------*/
+TEST(CurvedBlockingTestSuite, test_pillow_12)
+{
+    gmds::cad::FACManager geom_model;
+    setUp(geom_model);
+    gmds::blocking::CurvedBlocking bl(&geom_model, true);
+    gmds::blocking::CurvedBlockingClassifier cl(&bl);
+    cl.classify();
+
+    std::vector<std::vector<gmds::blocking::CurvedBlocking::Edge>> edges = bl.get_all_sheet_edge_sets();
+    for(auto par_edges_i:edges) {
+        bl.cut_sheet(par_edges_i[0]);
+    }
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),8);
+
+    std::vector<gmds::blocking::CurvedBlocking::Face> all_faces = bl.get_all_faces();
+    std::vector<gmds::blocking::CurvedBlocking::Face> surf;
+
+    surf.clear();
+    //We pick an inner surface
+    for(auto f:all_faces){
+        gmds::math::Point ci = bl.get_center_of_face(f);
+        if(fabs(ci.X())<0.1 ){
+            surf.push_back(f);
+        }
+        else if(ci.X() <0 && fabs(ci.Y()-5)<0.1 ){
+            surf.push_back(f);
+        }
+    }
+    ASSERT_EQ(surf.size(),6);
+
+    ASSERT_TRUE(bl.pillow(surf));
+
+    bl.smooth(10);
+
+    //export_vtk(bl,gmds::N | gmds::E, "pillow_12_surf.vtk");
+
+    ASSERT_EQ(bl.get_nb_cells<3>(),14);
+    auto [nb_nodes_on_vertex,nb_nodes_on_curve,nb_nodes_on_surface,nb_nodes_in_volume] = get_node_statistics(bl);
+    ASSERT_EQ(nb_nodes_on_vertex, 8);
+    ASSERT_EQ(nb_nodes_on_curve, 16);
+    ASSERT_EQ(nb_nodes_on_surface, 12);
+    ASSERT_EQ(nb_nodes_in_volume, 3);
+    auto [nb_edges_on_curve,nb_edges_on_surface,nb_edges_in_volume] = get_edge_statistics(bl);
+    ASSERT_EQ(nb_edges_on_curve, 28);
+    ASSERT_EQ(nb_edges_on_surface, 40);
+    ASSERT_EQ(nb_edges_in_volume, 15);
+    auto [nb_faces_on_surface,nb_faces_in_volume] = get_face_statistics(bl);
+    ASSERT_EQ(nb_faces_on_surface, 34);
+    ASSERT_EQ(nb_faces_in_volume, 25);
 }


### PR DESCRIPTION
The pillow operation works from a set of faces that must split the domain in two parts.
- surface validity is tested first
- we pillow inside and on the boundary of the domain
- the only forbidden pillow is when boundary faces are on the "two" sides of the input surfaces. In practice, two pillow sheets should be added. It will be an incoming improvement.
- classification is preserved during the pillow process (see unit tests)

Simple Laplacian smoothing for curved blocking
- smooth on curves, surfaces and in the volume