### PR TITLE
Issue 345 math component code coverage

### DIFF
--- a/math/tst/AxisAngleRotationTestSuite.h
+++ b/math/tst/AxisAngleRotationTestSuite.h
@@ -1,0 +1,136 @@
+#include <gtest/gtest.h>
+#include <gmds/math/AxisAngleRotation.h>
+
+using namespace gmds::math;
+
+// Test default constructor
+TEST(AxisAngleRotationClass, DefaultConstructor)
+{
+    AxisAngleRotation axisAngleRotation;
+    ASSERT_NO_THROW(axisAngleRotation.quaternion());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationMatrix());
+    ASSERT_NO_THROW(axisAngleRotation.toChart());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationAxis(0));
+    ASSERT_NO_THROW(axisAngleRotation * Vector3d({1.0, 0.0, 0.0}));
+}
+
+// Test constructor with axis and angle
+TEST(AxisAngleRotationClass, ConstructorWithAxisAndAngle)
+{
+    Vector3d axis({1.0, 0.0, 0.0});
+    double angle = M_PI / 2.0;
+    AxisAngleRotation axisAngleRotation(axis, angle);
+
+    ASSERT_NO_THROW(axisAngleRotation.quaternion());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationMatrix());
+    ASSERT_NO_THROW(axisAngleRotation.toChart());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationAxis(0));
+    ASSERT_NO_THROW(axisAngleRotation * Vector3d({1.0, 0.0, 0.0}));
+}
+
+// Test constructor with axis
+TEST(AxisAngleRotationClass, ConstructorWithAxis)
+{
+    Vector3d axis({1.0, 0.0, 0.0});
+    AxisAngleRotation axisAngleRotation(axis);
+
+    ASSERT_NO_THROW(axisAngleRotation.quaternion());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationMatrix());
+    ASSERT_NO_THROW(axisAngleRotation.toChart());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationAxis(0));
+    ASSERT_NO_THROW(axisAngleRotation * Vector3d({1.0, 0.0, 0.0}));
+}
+
+// Test constructor with quaternion
+TEST(AxisAngleRotationClass, ConstructorWithQuaternion)
+{
+    Quaternion quaternion(1.0, 0.0, 0.0, 0.0);
+    AxisAngleRotation axisAngleRotation(quaternion);
+
+    ASSERT_NO_THROW(axisAngleRotation.toRotationMatrix());
+    ASSERT_NO_THROW(axisAngleRotation.toChart());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationAxis(0));
+    ASSERT_NO_THROW(axisAngleRotation * Vector3d({1.0, 0.0, 0.0}));
+}
+
+// Test constructor with chart
+TEST(AxisAngleRotationClass, ConstructorWithChart)
+{
+    Chart chart(Vector3d({1.0, 0.0, 0.0}), Vector3d({0.0, 1.0, 0.0}), Vector3d({0.0, 0.0, 1.0}));
+    AxisAngleRotation axisAngleRotation(chart);
+
+    ASSERT_NO_THROW(axisAngleRotation.quaternion());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationMatrix());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationAxis(0));
+    ASSERT_NO_THROW(axisAngleRotation * Vector3d({1.0, 0.0, 0.0}));
+}
+
+// Test constructor between two vectors
+TEST(AxisAngleRotationClass, ConstructorBetweenTwoVectors)
+{
+    Vector3d fromVector({1.0, 0.0, 0.0});
+    Vector3d toVector({0.0, 1.0, 0.0});
+    AxisAngleRotation axisAngleRotation(fromVector, toVector);
+
+    ASSERT_NO_THROW(axisAngleRotation.quaternion());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationMatrix());
+    ASSERT_NO_THROW(axisAngleRotation.toChart());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationAxis(0));
+    ASSERT_NO_THROW(axisAngleRotation * Vector3d({1.0, 0.0, 0.0}));
+}
+
+// Test alignZ method
+TEST(AxisAngleRotationClass, AlignZMethod)
+{
+    Vector3d axis({1.0, 0.0, 0.0});
+    AxisAngleRotation axisAngleRotation = AxisAngleRotation::alignZ(axis);
+
+    ASSERT_NO_THROW(axisAngleRotation.quaternion());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationMatrix());
+    ASSERT_NO_THROW(axisAngleRotation.toChart());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationAxis(0));
+    ASSERT_NO_THROW(axisAngleRotation * Vector3d({1.0, 0.0, 0.0}));
+}
+
+// Test alignYZ method
+TEST(AxisAngleRotationClass, AlignYZMethod)
+{
+    Vector3d yAxis({0.0, 1.0, 0.0});
+    Vector3d zAxis({0.0, 0.0, 1.0});
+    AxisAngleRotation axisAngleRotation = AxisAngleRotation::alignYZ(yAxis, zAxis);
+
+    ASSERT_NO_THROW(axisAngleRotation.quaternion());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationMatrix());
+    ASSERT_NO_THROW(axisAngleRotation.toChart());
+    ASSERT_NO_THROW(axisAngleRotation.toRotationAxis(0));
+    ASSERT_NO_THROW(axisAngleRotation * Vector3d({1.0, 0.0, 0.0}));
+}
+
+// Test toRotationAxis method
+TEST(AxisAngleRotationClass, ToRotationAxisMethod)
+{
+    Vector3d axis({1.0, 0.0, 0.0});
+    AxisAngleRotation axisAngleRotation(axis);
+
+    Vector3d rotationAxis = axisAngleRotation.toRotationAxis(0);
+
+    ASSERT_EQ(rotationAxis, Vector3d({1.0, 0.0, 0.0}));
+}
+
+// Test multiplication operator
+TEST(AxisAngleRotationClass, MultiplicationOperator)
+{
+    Vector3d axis1({1.0, 0.0, 0.0});
+    AxisAngleRotation axisAngleRotation1(axis1);
+
+    Vector3d axis2({0.0, 1.0, 0.0});
+    AxisAngleRotation axisAngleRotation2(axis2);
+
+    AxisAngleRotation result = axisAngleRotation1 * axisAngleRotation2;
+
+    ASSERT_NO_THROW(result.quaternion());
+    ASSERT_NO_THROW(result.toRotationMatrix());
+    ASSERT_NO_THROW(result.toChart());
+    ASSERT_NO_THROW(result.toRotationAxis(0));
+    ASSERT_NO_THROW(result * Vector3d({1.0, 0.0, 0.0}));
+}

--- a/math/tst/BezierCurveTestSuite.h
+++ b/math/tst/BezierCurveTestSuite.h
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+#include <gmds/math/BezierCurve.h>
+
+// Test the constructor with three points
+TEST(BezierCurveTest, ConstructorWithThreePoints) {
+    gmds::math::Point p1(0, 0, 0);
+    gmds::math::Point p2(1, 1, 1);
+    gmds::math::Point p3(2, 2, 2);
+    
+    gmds::math::BezierCurve curve(p1, p2, p3);
+    
+    // Check if control points are correctly initialized
+    ASSERT_EQ(curve.getControlPoints().size(), 3);
+    ASSERT_EQ(curve.getControlPoints()[0], p1);
+    ASSERT_EQ(curve.getControlPoints()[1], p2);
+    ASSERT_EQ(curve.getControlPoints()[2], p3);
+}
+
+// Test the constructor with four points
+TEST(BezierCurveTest, ConstructorWithFourPoints) {
+    gmds::math::Point p1(0, 0, 0);
+    gmds::math::Point p2(1, 1, 1);
+    gmds::math::Point p3(2, 2, 2);
+    gmds::math::Point p4(3, 3, 3);
+    
+    gmds::math::BezierCurve curve(p1, p2, p3, p4);
+    
+    // Check if control points are correctly initialized
+    ASSERT_EQ(curve.getControlPoints().size(), 4);
+    ASSERT_EQ(curve.getControlPoints()[0], p1);
+    ASSERT_EQ(curve.getControlPoints()[1], p2);
+    ASSERT_EQ(curve.getControlPoints()[2], p3);
+    ASSERT_EQ(curve.getControlPoints()[3], p4);
+}
+
+// Test the operator () for different t parameters
+TEST(BezierCurveTest, OperatorFunction) {
+    gmds::math::Point p1(0, 0, 0);
+    gmds::math::Point p2(1, 1, 1);
+    gmds::math::Point p3(2, 2, 2);
+    
+    gmds::math::BezierCurve curve(p1, p2, p3);
+    
+    // Check if the return value is correct for t = 0, t = 0.5, t = 1
+    ASSERT_EQ(curve(0), p1);
+    ASSERT_NEAR(curve(0.5), gmds::math::Point(1, 1, 1), 1e-6);
+    ASSERT_EQ(curve(1), p3);
+}
+
+// Test the getDiscretization function for a given number of samples
+TEST(BezierCurveTest, GetDiscretization) {
+    gmds::math::Point p1(0, 0, 0);
+    gmds::math::Point p2(1, 1, 1);
+    gmds::math::Point p3(2, 2, 2);
+    
+    gmds::math::BezierCurve curve(p1, p2, p3);
+    
+    // Get the discretization with a certain number of samples and check its size
+    auto discretization = curve.getDiscretization(10);
+    ASSERT_EQ(discretization.size(), 11);  // Including 0
+}

--- a/math/tst/BezierTriangleTestSuite.h
+++ b/math/tst/BezierTriangleTestSuite.h
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+#include <gmds/math/BezierTriangle.h>
+
+using namespace gmds::math;
+
+TEST(BezierTriangleClass, ConstructeurParDefaut)
+{
+    // Test du constructeur par défaut
+    BezierTriangle bezierTriangle;
+    ASSERT_NO_THROW(bezierTriangle.operator()(0.0, 0.0));
+    ASSERT_NO_THROW(bezierTriangle.normal(0.0, 0.0));
+    ASSERT_NO_THROW(bezierTriangle.geomInfo(0.0, 0.0, Point(), Vector3d(), Vector3d(), Vector3d()));
+    ASSERT_NO_THROW(bezierTriangle.getDiscretization(10));
+}
+
+TEST(BezierTriangleClass, ConstructeurAvecPointsDeControleEtNormales)
+{
+    // Test du constructeur avec points de contrôle et normales
+    Point p1(0.0, 0.0, 0.0);
+    Point p2(1.0, 0.0, 0.0);
+    Point p3(0.0, 1.0, 0.0);
+
+    Vector3d n1(0.0, 0.0, 1.0);
+    Vector3d n2(0.0, 0.0, 1.0);
+    Vector3d n3(0.0, 0.0, 1.0);
+
+    BezierTriangle bezierTriangle(p1, p2, p3, n1, n2, n3);
+
+    ASSERT_NO_THROW(bezierTriangle.operator()(0.5, 0.5));
+    ASSERT_NO_THROW(bezierTriangle.normal(0.5, 0.5));
+    ASSERT_NO_THROW(bezierTriangle.geomInfo(0.5, 0.5, Point(), Vector3d(), Vector3d(), Vector3d()));
+    ASSERT_NO_THROW(bezierTriangle.getDiscretization(10));
+}
+
+TEST(BezierTriangleClass, EvaluationOperateur)
+{
+    // Test de l'évaluation de l'opérateur()
+    Point p1(0.0, 0.0, 0.0);
+    Point p2(1.0, 0.0, 0.0);
+    Point p3(0.0, 1.0, 0.0);
+
+    Vector3d n1(0.0, 0.0, 1.0);
+    Vector3d n2(0.0, 0.0, 1.0);
+    Vector3d n3(0.0, 0.0, 1.0);
+
+    BezierTriangle bezierTriangle(p1, p2, p3, n1, n2, n3);
+
+    // Test de l'évaluation du point à différentes coordonnées (u, v)
+    ASSERT_NO_THROW(bezierTriangle.operator()(0.0, 0.0));
+    ASSERT_NO_THROW(bezierTriangle.operator()(0.5, 0.5));
+    ASSERT_NO_THROW(bezierTriangle.operator()(1.0, 1.0));
+}
+
+TEST(BezierTriangleClass, CalculNormal)
+{
+    // Test du calcul de la normale à différentes coordonnées (u, v)
+    Point p1(0.0, 0.0, 0.0);
+    Point p2(1.0, 0.0, 0.0);
+    Point p3(0.0, 1.0, 0.0);
+
+    Vector3d n1(0.0, 0.0, 1.0);
+    Vector3d n2(0.0, 0.0, 1.0);
+    Vector3d n3(0.0, 0.0, 1.0);
+
+    BezierTriangle bezierTriangle(p1, p2, p3, n1, n2, n3);
+
+    ASSERT_NO_THROW(bezierTriangle.normal(0.0, 0.0));
+    ASSERT_NO_THROW(bezierTriangle.normal(0.5, 0.5));
+    ASSERT_NO_THROW(bezierTriangle.normal(1.0, 1.0));
+}
+
+TEST(BezierTriangleClass, InfoGeometrie)
+{
+    // Test de la méthode geomInfo à différentes coordonnées (u, v)
+    Point p1(0.0, 0.0, 0.0);
+    Point p2(1.0, 0.0, 0.0);
+    Point p3(0.0, 1.0, 0.0);
+
+    Vector3d n1(0.0, 0.0, 1.0);
+    Vector3d n2(0.0, 0.0, 1.0);
+    Vector3d n3(0.0, 0.0, 1.0);
+
+    BezierTriangle bezierTriangle(p1, p2, p3, n1, n2, n3);
+
+    Point pointResult;
+    Vector3d normalResult;
+    Vector3d duResult;
+    Vector3d dvResult;
+
+    ASSERT_NO_THROW(bezierTriangle.geomInfo(0.0, 0.0, pointResult, normalResult, duResult, dvResult));
+    ASSERT_NO_THROW(bezierTriangle.geomInfo(0.5, 0.5, pointResult, normalResult, duResult, dvResult));
+    ASSERT_NO_THROW(bezierTriangle.geomInfo(1.0, 1.0, pointResult, normalResult, duResult, dvResult));
+}
+
+TEST(BezierTriangleClass, Discretisation)
+{
+    // Test de la discrétisation à différentes résolutions
+    Point p1(0.0, 0.0, 0.0);
+    Point p2(1.0, 0.0, 0.0);
+    Point p3(0.0, 1.0, 0.0);
+
+    Vector3d n1(0.0, 0.0, 1.0);
+    Vector3d n2(0.0, 0.0, 1.0);
+    Vector3d n3(0.0, 0.0, 1.0);
+
+    BezierTriangle bezierTriangle(p1, p2, p3, n1, n2, n3);
+
+    ASSERT_NO_THROW(bezierTriangle.getDiscretization(10));
+    ASSERT_NO_THROW(bezierTriangle.getDiscretization(20));
+    ASSERT_NO_THROW(bezierTriangle.getDiscretization(30));
+}

--- a/math/tst/CMakeLists.txt
+++ b/math/tst/CMakeLists.txt
@@ -20,7 +20,9 @@ add_executable(GMDS_MATH_TEST
         QuadrilateralTestSuite.h
         PlaneTestSuite.h
         Prism3TestSuite.h
-        PyramidTestSuite.h)
+        PyramidTestSuite.h
+        QualityMeasureTestSuite.h
+        RayTestSuite.h)
 #==============================================================================
 target_link_libraries(GMDS_MATH_TEST PUBLIC
         ${GMDS_LIB}

--- a/math/tst/CMakeLists.txt
+++ b/math/tst/CMakeLists.txt
@@ -12,7 +12,8 @@ add_executable(GMDS_MATH_TEST
         BezierSurfaceTestSuite.h
         BezierCurveTestSuite.h
         BezierTriangleTestSuite.h
-        AxisAngleRotationTestSuite.h)
+        AxisAngleRotationTestSuite.h
+        FETestSuite.h)
 #==============================================================================
 target_link_libraries(GMDS_MATH_TEST PUBLIC
         ${GMDS_LIB}

--- a/math/tst/CMakeLists.txt
+++ b/math/tst/CMakeLists.txt
@@ -22,7 +22,8 @@ add_executable(GMDS_MATH_TEST
         Prism3TestSuite.h
         PyramidTestSuite.h
         QualityMeasureTestSuite.h
-        RayTestSuite.h)
+        RayTestSuite.h
+        SegmentTestSuite.h)
 #==============================================================================
 target_link_libraries(GMDS_MATH_TEST PUBLIC
         ${GMDS_LIB}

--- a/math/tst/CMakeLists.txt
+++ b/math/tst/CMakeLists.txt
@@ -17,7 +17,8 @@ add_executable(GMDS_MATH_TEST
         HexahedronTestSuite.h
         LineTestSuite.h
         NumericsTestSuite.h
-        QuadrilateralTestSuite.h)
+        QuadrilateralTestSuite.h
+        PlaneTestSuite.h)
 #==============================================================================
 target_link_libraries(GMDS_MATH_TEST PUBLIC
         ${GMDS_LIB}

--- a/math/tst/CMakeLists.txt
+++ b/math/tst/CMakeLists.txt
@@ -15,7 +15,8 @@ add_executable(GMDS_MATH_TEST
         AxisAngleRotationTestSuite.h
         FETestSuite.h
         HexahedronTestSuite.h
-        LineTestSuite.h)
+        LineTestSuite.h
+        NumericsTestSuite.h)
 #==============================================================================
 target_link_libraries(GMDS_MATH_TEST PUBLIC
         ${GMDS_LIB}

--- a/math/tst/CMakeLists.txt
+++ b/math/tst/CMakeLists.txt
@@ -18,7 +18,8 @@ add_executable(GMDS_MATH_TEST
         LineTestSuite.h
         NumericsTestSuite.h
         QuadrilateralTestSuite.h
-        PlaneTestSuite.h)
+        PlaneTestSuite.h
+        Prism3TestSuite.h)
 #==============================================================================
 target_link_libraries(GMDS_MATH_TEST PUBLIC
         ${GMDS_LIB}

--- a/math/tst/CMakeLists.txt
+++ b/math/tst/CMakeLists.txt
@@ -11,7 +11,8 @@ add_executable(GMDS_MATH_TEST
         main_test.cpp
         BezierSurfaceTestSuite.h
         BezierCurveTestSuite.h
-        BezierTriangleTestSuite.h)
+        BezierTriangleTestSuite.h
+        AxisAngleRotationTestSuite.h)
 #==============================================================================
 target_link_libraries(GMDS_MATH_TEST PUBLIC
         ${GMDS_LIB}

--- a/math/tst/CMakeLists.txt
+++ b/math/tst/CMakeLists.txt
@@ -10,7 +10,8 @@ add_executable(GMDS_MATH_TEST
         TransfiniteInterpolationTestSuite.h
         main_test.cpp
         BezierSurfaceTestSuite.h
-        BezierCurveTestSuite.h)
+        BezierCurveTestSuite.h
+        BezierTriangleTestSuite.h)
 #==============================================================================
 target_link_libraries(GMDS_MATH_TEST PUBLIC
         ${GMDS_LIB}

--- a/math/tst/CMakeLists.txt
+++ b/math/tst/CMakeLists.txt
@@ -14,7 +14,8 @@ add_executable(GMDS_MATH_TEST
         BezierTriangleTestSuite.h
         AxisAngleRotationTestSuite.h
         FETestSuite.h
-        HexahedronTestSuite.h)
+        HexahedronTestSuite.h
+        LineTestSuite.h)
 #==============================================================================
 target_link_libraries(GMDS_MATH_TEST PUBLIC
         ${GMDS_LIB}

--- a/math/tst/CMakeLists.txt
+++ b/math/tst/CMakeLists.txt
@@ -19,7 +19,8 @@ add_executable(GMDS_MATH_TEST
         NumericsTestSuite.h
         QuadrilateralTestSuite.h
         PlaneTestSuite.h
-        Prism3TestSuite.h)
+        Prism3TestSuite.h
+        PyramidTestSuite.h)
 #==============================================================================
 target_link_libraries(GMDS_MATH_TEST PUBLIC
         ${GMDS_LIB}

--- a/math/tst/CMakeLists.txt
+++ b/math/tst/CMakeLists.txt
@@ -13,7 +13,8 @@ add_executable(GMDS_MATH_TEST
         BezierCurveTestSuite.h
         BezierTriangleTestSuite.h
         AxisAngleRotationTestSuite.h
-        FETestSuite.h)
+        FETestSuite.h
+        HexahedronTestSuite.h)
 #==============================================================================
 target_link_libraries(GMDS_MATH_TEST PUBLIC
         ${GMDS_LIB}

--- a/math/tst/CMakeLists.txt
+++ b/math/tst/CMakeLists.txt
@@ -16,7 +16,8 @@ add_executable(GMDS_MATH_TEST
         FETestSuite.h
         HexahedronTestSuite.h
         LineTestSuite.h
-        NumericsTestSuite.h)
+        NumericsTestSuite.h
+        QuadrilateralTestSuite.h)
 #==============================================================================
 target_link_libraries(GMDS_MATH_TEST PUBLIC
         ${GMDS_LIB}

--- a/math/tst/CMakeLists.txt
+++ b/math/tst/CMakeLists.txt
@@ -9,7 +9,8 @@ add_executable(GMDS_MATH_TEST
         OrientationTestSuite.h
         TransfiniteInterpolationTestSuite.h
         main_test.cpp
-        BezierSurfaceTestSuite.h)
+        BezierSurfaceTestSuite.h
+        BezierCurveTestSuite.h)
 #==============================================================================
 target_link_libraries(GMDS_MATH_TEST PUBLIC
         ${GMDS_LIB}

--- a/math/tst/FETestSuite.h
+++ b/math/tst/FETestSuite.h
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+#include <gmds/math/Segment.h>
+#include <gmds/math/FE.h>
+
+using namespace gmds::math;
+
+
+TEST(TriangleP1, BMatrixCalculation)
+{
+    // Given three points representing a triangle
+    Point P1({0.0, 0.0});
+    Point P2({1.0, 0.0});
+    Point P3({0.0, 1.0});
+
+    // When calculating the B matrix
+    auto B_matrix = TriangleP1::B(P1, P2, P3);
+
+    // Then the B matrix should be correctly calculated
+    ASSERT_EQ(B_matrix.rows(), 2);
+    ASSERT_EQ(B_matrix.columns(), 2);
+}
+
+TEST(TriangleP1, StiffnessMatrixCalculation)
+{
+    // Given three points representing a triangle
+    Point P1({0.0, 0.0});
+    Point P2({1.0, 0.0});
+    Point P3({0.0, 1.0});
+
+    // When calculating the stiffness matrix
+    auto stiffness_matrix = TriangleP1::stiffnessMatrix(P1, P2, P3);
+
+    // Then the stiffness matrix should be correctly calculated
+    ASSERT_EQ(stiffness_matrix.rows(), 3);
+    ASSERT_EQ(stiffness_matrix.columns(), 3);
+}
+
+TEST(TetrahedronP1, StiffnessMatrixCalculation)
+{
+    // Given four points representing a tetrahedron
+    Point P1({0.0, 0.0});
+    Point P2({1.0, 0.0});
+    Point P3({0.0, 1.0});
+    Point P4({0.0, 0.0, 1.0});
+
+    // When calculating the stiffness matrix
+    auto stiffness_matrix = TetrahedronP1::stiffnessMatrix(P1, P2, P3, P4);
+
+    // Then the stiffness matrix should be correctly calculated
+    ASSERT_EQ(stiffness_matrix.rows(), 4);
+    ASSERT_EQ(stiffness_matrix.columns(), 4);
+}

--- a/math/tst/HexahedronTestSuite.h
+++ b/math/tst/HexahedronTestSuite.h
@@ -1,0 +1,88 @@
+#include <gtest/gtest.h>
+#include <gmds/math/Hexahedron.h>
+#include <gmds/math/Point.h>
+#include <gmds/math/Triangle.h>
+
+using namespace gmds::math;
+
+TEST(Hexahedron, Constructors)
+{
+    // Hexahedron created using different constructors
+
+    Hexahedron hex1; // Default constructor
+    Hexahedron hex2(Point(0, 0, 0), Point(1, 0, 0), Point(1, 1, 0), Point(0, 1, 0),
+                    Point(0, 0, 1), Point(1, 0, 1), Point(1, 1, 1), Point(0, 1, 1)); // Constructor with individual points
+    Hexahedron hex3({Point(0, 0, 0), Point(1, 0, 0), Point(1, 1, 0), Point(0, 1, 0),
+                     Point(0, 0, 1), Point(1, 0, 1), Point(1, 1, 1), Point(0, 1, 1)}); // Constructor with an array of points
+    Hexahedron hex4(std::vector<Point>{Point(0, 0, 0), Point(1, 0, 0), Point(1, 1, 0), Point(0, 1, 0),
+                                       Point(0, 0, 1), Point(1, 0, 1), Point(1, 1, 1), Point(0, 1, 1)}); // Constructor with a vector of points
+    Hexahedron hex5(hex1); // Copy constructor
+
+    // Verify that the Hexahedron objects are correctly initialized
+
+    ASSERT_TRUE(hex1.isValid());
+    ASSERT_TRUE(hex2.isValid());
+    ASSERT_TRUE(hex3.isValid());
+    ASSERT_TRUE(hex4.isValid());
+    ASSERT_TRUE(hex5.isValid());
+}
+
+TEST(Hexahedron, Getters)
+{
+    // Given a Hexahedron
+
+    Hexahedron hex(Point(0, 0, 0), Point(1, 0, 0), Point(1, 1, 0), Point(0, 1, 0),
+                   Point(0, 0, 1), Point(1, 0, 1), Point(1, 1, 1), Point(0, 1, 1));
+
+    // When retrieving the center, volume, and other properties
+
+    Point center = hex.getCenter();
+    double volume = hex.getVolume();
+    bool isValid = hex.isValid();
+    double meanEdgeLength = hex.computeMeanEdgeLength();
+
+    // Verify the correctness of the results
+
+    ASSERT_EQ(center, Point(0.5, 0.5, 0.5));
+    ASSERT_GT(volume, 0);
+    ASSERT_TRUE(isValid);
+    ASSERT_GT(meanEdgeLength, 0);
+}
+
+TEST(Hexahedron, Intersect)
+{
+    // Given a Hexahedron and a Triangle
+
+    Hexahedron hex(Point(0, 0, 0), Point(1, 0, 0), Point(1, 1, 0), Point(0, 1, 0),
+                   Point(0, 0, 1), Point(1, 0, 1), Point(1, 1, 1), Point(0, 1, 1));
+
+    Triangle tri(Point(0.5, 0.5, -0.5), Point(1.5, 0.5, -0.5), Point(1.5, 1.5, -0.5));
+
+    // When checking for intersection
+
+    bool isIntersecting = hex.intersect(tri);
+
+    // Then, verify the correctness of the result
+
+    ASSERT_TRUE(isIntersecting);
+}
+
+TEST(Hexahedron, Jacobian)
+{
+    // Given a Hexahedron
+
+    Hexahedron hex(Point(0, 0, 0), Point(1, 0, 0), Point(1, 1, 0), Point(0, 1, 0),
+                   Point(0, 0, 1), Point(1, 0, 1), Point(1, 1, 1), Point(0, 1, 1));
+
+    // When calculating the Jacobian matrix for each vertex
+
+    Matrix<3, 3, double> jacobian0 = hex.jacobian(0);
+    Matrix<3, 3, double> jacobian1 = hex.jacobian(1);
+    Matrix<3, 3, double> jacobian2 = hex.jacobian(2);
+    Matrix<3, 3, double> jacobian3 = hex.jacobian(3);
+    Matrix<3, 3, double> jacobian4 = hex.jacobian(4);
+    Matrix<3, 3, double> jacobian5 = hex.jacobian(5);
+    Matrix<3, 3, double> jacobian6 = hex.jacobian(6);
+    Matrix<3, 3, double> jacobian7 = hex.jacobian(7);
+
+}

--- a/math/tst/LineTestSuite.h
+++ b/math/tst/LineTestSuite.h
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+#include "YourGeometryLibrary.h" 
+
+// Test case for Line-Triangle intersection
+TEST(LineTriangleIntersection, IntersectionCheck) {
+    // Create a Line and a Triangle for testing
+    Line line(Point(0, 0, 0), Point(1, 1, 1));
+    Triangle triangle(Point(0, 0, 0), Point(1, 0, 0), Point(0, 1, 0));
+
+    // Check intersection
+    bool result = line.intersect(triangle, someParameterValue);
+    ASSERT_TRUE(result);
+}
+
+// Test case for Line projection
+TEST(LineProjection, ProjectPoint) {
+    // Create a Line and a Point for testing
+    Line line(Point(0, 0, 0), Point(1, 1, 1));
+    Point pointToProject(2, 2, 2);
+
+    // Project the point onto the line
+    Point projectedPoint = line.project(pointToProject);
+
+    // Check if the projected point is correct
+    ASSERT_EQ(projectedPoint, Point(1, 1, 1));
+}
+
+// Test case for Line-Segment 2D distance computation
+TEST(LineSegmentDistance, Distance2DCheck) {
+    // Create a Line and a Segment for testing
+    Line line(Point(0, 0, 0), Point(1, 1, 1));
+    Segment segment(Point(0, 0, 0), Point(2, 2, 2));
+
+    // Variables to store the closest points
+    Point closestPoint1, closestPoint2;
+
+    // Compute the 2D distance between the Line and the Segment
+    TCoord distance = line.distance2D(segment, closestPoint1, closestPoint2);
+
+    // Check if the computed distance is correct
+    ASSERT_EQ(distance, sqrt(3));
+
+    // Check if the closest points are correct
+    ASSERT_EQ(closestPoint1, Point(1, 1, 1));
+    ASSERT_EQ(closestPoint2, Point(1, 1, 1));
+}

--- a/math/tst/NumericsTestSuite.h
+++ b/math/tst/NumericsTestSuite.h
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+#include <gmds/math/Numerics.h>
+
+using namespace gmds::math;
+
+// Test for the modulo function
+TEST(NumericsTest, ModuloTest) {
+    // Test with positive values
+    ASSERT_DOUBLE_EQ(modulo(10.0, 3.0), 1.0);
+    // Test with negative values
+    ASSERT_DOUBLE_EQ(modulo(-10.0, 3.0), 2.0);
+}
+
+// Test for the modulo2PI function
+TEST(NumericsTest, Modulo2PITest) {
+    ASSERT_DOUBLE_EQ(modulo2PI(7.0), 1.0);
+    ASSERT_DOUBLE_EQ(modulo2PI(-7.0), 5.0);
+}
+
+// Tests for the min and max functions
+TEST(NumericsTest, MinMaxTest) {
+    // Test with two values
+    ASSERT_DOUBLE_EQ(min2(3.0, 5.0), 3.0);
+    ASSERT_DOUBLE_EQ(max2(3.0, 5.0), 5.0);
+
+    // Test with three values
+    ASSERT_DOUBLE_EQ(min3(3.0, 5.0, 2.0), 2.0);
+    ASSERT_DOUBLE_EQ(max3(3.0, 5.0, 2.0), 5.0);
+
+    // Test with four values
+    ASSERT_DOUBLE_EQ(min4(3.0, 5.0, 2.0, 8.0), 2.0);
+    ASSERT_DOUBLE_EQ(max4(3.0, 5.0, 2.0, 8.0), 8.0);
+
+    // Test with eight values
+    ASSERT_DOUBLE_EQ(min8(3.0, 5.0, 2.0, 8.0, 1.0, 6.0, 7.0, 4.0), 1.0);
+    ASSERT_DOUBLE_EQ(max8(3.0, 5.0, 2.0, 8.0, 1.0, 6.0, 7.0, 4.0), 8.0);
+}
+
+// Test for the isZero function
+TEST(NumericsTest, IsZeroTest) {
+    ASSERT_TRUE(isZero(0.0, 1e-6));
+    ASSERT_TRUE(isZero(0.0, Constants::EPSILON));
+    ASSERT_FALSE(isZero(0.00001, 1e-6));
+}
+
+// Test for the areEquals function
+TEST(NumericsTest, AreEqualsTest) {
+    ASSERT_TRUE(areEquals(1.0, 1.0, 1e-6));
+    ASSERT_TRUE(areEquals(1.0, 1.00001, 1e-6));
+    ASSERT_FALSE(areEquals(1.0, 2.0, 1e-6));
+}
+
+// Test for the dihedralAngle function
+TEST(NumericsTest, DihedralAngleTest) {
+    Point A(0, 0, 0);
+    Point B(1, 0, 0);
+    Point C(1, 1, 0);
+    Point D(0, 1, 1);
+
+    ASSERT_DOUBLE_EQ(dihedralAngle(A, B, C, D), Constants::PI / 4.0);
+}
+
+// Test for the cotangentWeight function
+TEST(NumericsTest, CotangentWeightTest) {
+    Point A(0, 0, 0);
+    Point B(1, 0, 0);
+    Point C(1, 1, 0);
+    Point D(0, 1, 1);
+
+    ASSERT_DOUBLE_EQ(cotangentWeight(A, B, C, D), 0.125);
+}
+
+// Test for the intersectBoundingBox function
+TEST(NumericsTest, IntersectBoundingBoxTest) {
+    double minXYZ0[3] = {0.0, 0.0, 0.0};
+    double maxXYZ0[3] = {1.0, 1.0, 1.0};
+
+    double minXYZ1[3] = {0.5, 0.5, 0.5};
+    double maxXYZ1[3] = {1.5, 1.5, 1.5};
+
+    double minXYZ2[3] = {2.0, 2.0, 2.0};
+    double maxXYZ2[3] = {3.0, 3.0, 3.0};
+
+    ASSERT_TRUE(intersectBoundingBox(minXYZ0, maxXYZ0, minXYZ1, maxXYZ1));
+    ASSERT_FALSE(intersectBoundingBox(minXYZ0, maxXYZ0, minXYZ2, maxXYZ2));
+}

--- a/math/tst/PlaneTestSuite.h
+++ b/math/tst/PlaneTestSuite.h
@@ -1,0 +1,166 @@
+/*----------------------------------------------------------------------------*/
+#include <gtest/gtest.h>
+#include <gmds/math/Plane.h>
+#include <gmds/math/Point.h>
+#include <gmds/math/Segment.h>
+/*----------------------------------------------------------------------------*/
+TEST(Plane, testPlaneConstructors)
+{
+    // Test default constructor
+    gmds::math::Plane plane1;
+    ASSERT_EQ(gmds::math::Point(), plane1.getPoint());
+    ASSERT_EQ(gmds::math::Vector3d(), plane1.getNormal());
+
+    // Test constructor with a point and normal vector
+    gmds::math::Point point2(1.0, 2.0, 3.0);
+    gmds::math::Vector3d normal2(4.0, 5.0, 6.0);
+    gmds::math::Plane plane2(point2, normal2);
+    ASSERT_EQ(point2, plane2.getPoint());
+    ASSERT_EQ(normal2.normalized(), plane2.getNormal());
+
+    // Test constructor with three points
+    gmds::math::Point point3(1.0, 2.0, 3.0);
+    gmds::math::Point point4(4.0, 5.0, 6.0);
+    gmds::math::Point point5(7.0, 8.0, 9.0);
+    gmds::math::Plane plane3(point3, point4, point5);
+    gmds::math::Vector3d expectedNormal3 = (point4 - point3).cross(point5 - point3).normalized();
+    ASSERT_EQ(point3, plane3.getPoint());
+    ASSERT_EQ(expectedNormal3, plane3.getNormal());
+
+    // Test constructor with a Triangle
+    gmds::math::Triangle triangle(point3, point4, point5);
+    gmds::math::Plane plane4(triangle);
+    ASSERT_EQ(point3, plane4.getPoint());
+    ASSERT_EQ(expectedNormal3, plane4.getNormal());
+}
+
+TEST(Plane, testEqualityOperators)
+{
+    gmds::math::Point point1(1.0, 2.0, 3.0);
+    gmds::math::Vector3d normal1(4.0, 5.0, 6.0);
+    gmds::math::Plane plane1(point1, normal1);
+
+    gmds::math::Point point2(1.0, 2.0, 3.0);
+    gmds::math::Vector3d normal2(4.0, 5.0, 6.0);
+    gmds::math::Plane plane2(point2, normal2);
+
+    gmds::math::Point point3(7.0, 8.0, 9.0);
+    gmds::math::Vector3d normal3(10.0, 11.0, 12.0);
+    gmds::math::Plane plane3(point3, normal3);
+
+    ASSERT_EQ(plane1, plane2);
+    ASSERT_NE(plane1, plane3);
+}
+
+TEST(Plane, testIsIn)
+{
+    gmds::math::Point point(1.0, 2.0, 3.0);
+    gmds::math::Vector3d normal(4.0, 5.0, 6.0);
+    gmds::math::Plane plane(point, normal);
+
+    gmds::math::Point pointInPlane(5.0, 4.0, 3.0);
+    gmds::math::Point pointNotInPlane(7.0, 8.0, 9.0);
+
+    ASSERT_TRUE(plane.isIn(pointInPlane));
+    ASSERT_FALSE(plane.isIn(pointNotInPlane));
+}
+
+TEST(Plane, testIsStrictlyOnLeft)
+{
+    gmds::math::Point point(1.0, 2.0, 3.0);
+    gmds::math::Vector3d normal(4.0, 5.0, 6.0);
+    gmds::math::Plane plane(point, normal);
+
+    gmds::math::Point pointLeft(2.0, 3.0, 4.0);
+    gmds::math::Point pointRight(0.0, 1.0, 2.0);
+
+    ASSERT_TRUE(plane.isStrictlyOnLeft(pointLeft));
+    ASSERT_FALSE(plane.isStrictlyOnLeft(pointRight));
+}
+
+TEST(Plane, testDistance)
+{
+    gmds::math::Point point(1.0, 2.0, 3.0);
+    gmds::math::Vector3d normal(4.0, 5.0, 6.0);
+    gmds::math::Plane plane(point, normal);
+
+    gmds::math::Point pointOnPlane(5.0, 4.0, 3.0);
+    gmds::math::Point pointNotOnPlane(7.0, 8.0, 9.0);
+
+    ASSERT_DOUBLE_EQ(0.0, plane.distance(pointOnPlane));
+    ASSERT_DOUBLE_EQ(plane.distance(pointNotOnPlane), plane.distance(-pointNotOnPlane));
+}
+
+TEST(Plane, testProject)
+{
+    gmds::math::Point point(1.0, 2.0, 3.0);
+    gmds::math::Vector3d normal(4.0, 5.0, 6.0);
+    gmds::math::Plane plane(point, normal);
+
+    gmds::math::Point pointOnPlane(5.0, 4.0, 3.0);
+    gmds::math::Point pointNotOnPlane(7.0, 8.0, 9.0);
+
+    ASSERT_EQ(pointOnPlane, plane.project(pointOnPlane));
+    ASSERT_EQ(point, plane.project(pointNotOnPlane));
+}
+
+TEST(Plane, testIntersect)
+{
+    // Define a plane (1,0,0) passing through (0,0,0)
+    gmds::math::Point planePoint(0.0, 0.0, 0.0);
+    gmds::math::Vector3d planeNormal(1.0, 0.0, 0.0);
+    gmds::math::Plane plane(planePoint, planeNormal);
+
+    // Define a segment parallel to the plane
+    gmds::math::Point segPoint1(0.0, 1.0, 2.0);
+    gmds::math::Point segPoint2(0.0, 3.0, 4.0);
+    gmds::math::Segment segmentParallel(segPoint1, segPoint2);
+
+    // Define a segment intersecting the plane
+    gmds::math::Point segPoint3(2.0, 1.0, 0.0);
+    gmds::math::Point segPoint4(4.0, 3.0, 0.0);
+    gmds::math::Segment segmentIntersecting(segPoint3, segPoint4);
+
+    // Define a segment not intersecting the plane
+    gmds::math::Point segPoint5(0.0, 1.0, 4.0);
+    gmds::math::Point segPoint6(0.0, 3.0, 6.0);
+    gmds::math::Segment segmentNotIntersecting(segPoint5, segPoint6);
+
+    // Test intersection
+    ASSERT_TRUE(plane.intersect(segmentParallel, true));
+    ASSERT_TRUE(plane.intersect(segmentIntersecting, true));
+    ASSERT_FALSE(plane.intersect(segmentNotIntersecting, true));
+}
+
+TEST(Plane, testIntersectDetails)
+{
+    // Define a plane (1,0,0) passing through (0,0,0)
+    gmds::math::Point planePoint(0.0, 0.0, 0.0);
+    gmds::math::Vector3d planeNormal(1.0, 0.0, 0.0);
+    gmds::math::Plane plane(planePoint, planeNormal);
+
+    // Define a segment parallel to the plane
+    gmds::math::Point segPoint1(0.0, 1.0, 2.0);
+    gmds::math::Point segPoint2(0.0, 3.0, 4.0);
+    gmds::math::Segment segmentParallel(segPoint1, segPoint2);
+
+    // Define a segment intersecting the plane
+    gmds::math::Point segPoint3(2.0, 1.0, 0.0);
+    gmds::math::Point segPoint4(4.0, 3.0, 0.0);
+    gmds::math::Segment segmentIntersecting(segPoint3, segPoint4);
+
+    // Define a segment not intersecting the plane
+    gmds::math::Point segPoint5(0.0, 1.0, 4.0);
+    gmds::math::Point segPoint6(0.0, 3.0, 6.0);
+    gmds::math::Segment segmentNotIntersecting(segPoint5, segPoint6);
+
+    // Variables to store intersection details
+    gmds::math::Point intersectionPoint;
+    double w0, w1;
+
+    // Test intersection details
+    ASSERT_EQ(gmds::math::Plane::NO_INTERSECTION, plane.intersect(segmentParallel, intersectionPoint, w0, w1, true));
+    ASSERT_EQ(gmds::math::Plane::SEGMENT_MIDDLE, plane.intersect(segmentIntersecting, intersectionPoint, w0, w1, true));
+    ASSERT_EQ(gmds::math::Plane::NO_INTERSECTION, plane.intersect(segmentNotIntersecting, intersectionPoint, w0, w1, true));
+}
+/*----------------------------------------------------------------------------*/

--- a/math/tst/Prism3TestSuite.h
+++ b/math/tst/Prism3TestSuite.h
@@ -1,0 +1,104 @@
+/*----------------------------------------------------------------------------*/
+#include <gtest/gtest.h>
+#include <gmds/math/Prism3.h>
+#include <gmds/math/Point.h>
+#include <gmds/math/Tetrahedron.h>
+#include <gmds/math/Pyramid.h>
+#include <gmds/math/Triangle.h>
+/*----------------------------------------------------------------------------*/
+TEST(Prism3, testPrism3Constructor)
+{
+    // Test default constructor
+    gmds::math::Prism3 prism1;
+    ASSERT_EQ(gmds::math::Point(0, 0, 0), prism1.getPoint(0));
+
+    // Test constructor with specified points
+    gmds::math::Point points[6] = {
+        gmds::math::Point(1, 2, 3),
+        gmds::math::Point(4, 5, 6),
+        gmds::math::Point(7, 8, 9),
+        gmds::math::Point(10, 11, 12),
+        gmds::math::Point(13, 14, 15),
+        gmds::math::Point(16, 17, 18)
+    };
+
+    gmds::math::Prism3 prism2(points);
+    ASSERT_EQ(points[0], prism2.getPoint(0));
+    ASSERT_EQ(points[1], prism2.getPoint(1));
+    ASSERT_EQ(points[2], prism2.getPoint(2));
+    ASSERT_EQ(points[3], prism2.getPoint(3));
+    ASSERT_EQ(points[4], prism2.getPoint(4));
+    ASSERT_EQ(points[5], prism2.getPoint(5));
+}
+
+TEST(Prism3, testPrism3Center)
+{
+    gmds::math::Point points[6] = {
+        gmds::math::Point(1, 2, 3),
+        gmds::math::Point(4, 5, 6),
+        gmds::math::Point(7, 8, 9),
+        gmds::math::Point(10, 11, 12),
+        gmds::math::Point(13, 14, 15),
+        gmds::math::Point(16, 17, 18)
+    };
+
+    gmds::math::Prism3 prism(points);
+
+    // Test center calculation
+    gmds::math::Point center = prism.getCenter();
+    ASSERT_EQ(gmds::math::Point(8.5, 9.5, 10.5), center);
+}
+
+TEST(Prism3, testPrism3Volume)
+{
+    gmds::math::Point points[6] = {
+        gmds::math::Point(0, 0, 0),
+        gmds::math::Point(1, 0, 0),
+        gmds::math::Point(0, 1, 0),
+        gmds::math::Point(0, 0, 1),
+        gmds::math::Point(1, 0, 1),
+        gmds::math::Point(0, 1, 1)
+    };
+
+    gmds::math::Prism3 prism(points);
+
+    // Test volume calculation
+    double volume = prism.getVolume();
+    ASSERT_DOUBLE_EQ(0.5, volume);
+}
+
+TEST(Prism3, testPrism3ScaledJacobian)
+{
+    gmds::math::Point points[6] = {
+        gmds::math::Point(0, 0, 0),
+        gmds::math::Point(1, 0, 0),
+        gmds::math::Point(0, 1, 0),
+        gmds::math::Point(0, 0, 1),
+        gmds::math::Point(1, 0, 1),
+        gmds::math::Point(0, 1, 1)
+    };
+
+    gmds::math::Prism3 prism(points);
+
+    // Test scaled Jacobian calculation
+    double scaledJacobian = prism.computeScaledJacobian();
+    ASSERT_DOUBLE_EQ(1.0, scaledJacobian);
+}
+
+TEST(Prism3, testPrism3NormalizedScaledJacobian)
+{
+    gmds::math::Point points[6] = {
+        gmds::math::Point(0, 0, 0),
+        gmds::math::Point(1, 0, 0),
+        gmds::math::Point(0, 1, 0),
+        gmds::math::Point(0, 0, 1),
+        gmds::math::Point(1, 0, 1),
+        gmds::math::Point(0, 1, 1)
+    };
+
+    gmds::math::Prism3 prism(points);
+
+    // Test normalized scaled Jacobian calculation
+    double normalizedScaledJacobian = prism.computeNormalizedScaledJacobian();
+    ASSERT_DOUBLE_EQ(sqrt(3) / 2.0, normalizedScaledJacobian);
+}

--- a/math/tst/PyramidTestSuite.h
+++ b/math/tst/PyramidTestSuite.h
@@ -1,0 +1,97 @@
+/*----------------------------------------------------------------------------*/
+#include <gtest/gtest.h>
+#include <gmds/math/Pyramid.h>
+#include <gmds/math/Point.h>
+#include <gmds/math/Tetrahedron.h>
+#include <gmds/math/Triangle.h>
+/*----------------------------------------------------------------------------*/
+TEST(Pyramid, testPyramidConstructor)
+{
+    // Test default constructor
+    gmds::math::Pyramid pyramid1;
+    ASSERT_EQ(gmds::math::Point(0, 0, 0), pyramid1.getPoint(0));
+
+    // Test constructor with specified points
+    gmds::math::Point points[5] = {
+        gmds::math::Point(1, 2, 3),
+        gmds::math::Point(4, 5, 6),
+        gmds::math::Point(7, 8, 9),
+        gmds::math::Point(10, 11, 12),
+        gmds::math::Point(13, 14, 15)
+    };
+
+    gmds::math::Pyramid pyramid2(points);
+    ASSERT_EQ(points[0], pyramid2.getPoint(0));
+    ASSERT_EQ(points[1], pyramid2.getPoint(1));
+    ASSERT_EQ(points[2], pyramid2.getPoint(2));
+    ASSERT_EQ(points[3], pyramid2.getPoint(3));
+    ASSERT_EQ(points[4], pyramid2.getPoint(4));
+}
+
+TEST(Pyramid, testPyramidCenter)
+{
+    gmds::math::Point points[5] = {
+        gmds::math::Point(1, 2, 3),
+        gmds::math::Point(4, 5, 6),
+        gmds::math::Point(7, 8, 9),
+        gmds::math::Point(10, 11, 12),
+        gmds::math::Point(13, 14, 15)
+    };
+
+    gmds::math::Pyramid pyramid(points);
+
+    // Test center calculation
+    gmds::math::Point center = pyramid.getCenter();
+    ASSERT_EQ(gmds::math::Point(7, 8, 9), center);
+}
+
+TEST(Pyramid, testPyramidVolume)
+{
+    gmds::math::Point points[5] = {
+        gmds::math::Point(0, 0, 0),
+        gmds::math::Point(1, 0, 0),
+        gmds::math::Point(1, 1, 0),
+        gmds::math::Point(0, 1, 0),
+        gmds::math::Point(0, 0, 1)
+    };
+
+    gmds::math::Pyramid pyramid(points);
+
+    // Test volume calculation
+    double volume = pyramid.getVolume();
+    ASSERT_DOUBLE_EQ(1. / 6., volume);
+}
+
+TEST(Pyramid, testPyramidScaledJacobian)
+{
+    gmds::math::Point points[5] = {
+        gmds::math::Point(0, 0, 0),
+        gmds::math::Point(1, 0, 0),
+        gmds::math::Point(1, 1, 0),
+        gmds::math::Point(0, 1, 0),
+        gmds::math::Point(0, 0, 1)
+    };
+
+    gmds::math::Pyramid pyramid(points);
+
+    // Test scaled Jacobian calculation
+    double scaledJacobian = pyramid.computeScaledJacobian();
+    ASSERT_DOUBLE_EQ(1. / 3., scaledJacobian);
+}
+
+TEST(Pyramid, testPyramidNormalizedScaledJacobian)
+{
+    gmds::math::Point points[5] = {
+        gmds::math::Point(0, 0, 0),
+        gmds::math::Point(1, 0, 0),
+        gmds::math::Point(1, 1, 0),
+        gmds::math::Point(0, 1, 0),
+        gmds::math::Point(0, 0, 1)
+    };
+
+    gmds::math::Pyramid pyramid(points);
+
+    // Test normalized scaled Jacobian calculation
+    double normalizedScaledJacobian = pyramid.computeNormalizedScaledJacobian();
+    ASSERT_DOUBLE_EQ(sqrt(2. / 3.), normalizedScaledJacobian);
+}

--- a/math/tst/QuadrilateralTestSuite.h
+++ b/math/tst/QuadrilateralTestSuite.h
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+#include <gtest/gtest.h>
+#include <gmds/math/QualityMeasure.h>
+#include <gmds/math/Point.h>
+#include <gmds/math/Vector.h>
+#include <gmds/math/Triangle.h>
+/*----------------------------------------------------------------------------*/
+using namespace gmds::math;
+/*----------------------------------------------------------------------------*/
+TEST(QualityMeasureClass, testSphereRatio)
+{
+    // Define points for a tetrahedron
+    Point p0(0, 0, 0), p1(1, 0, 0), p2(0.5, 1, 0), p3(0.5, 0.5, 1);
+
+    double ratio = QualityMeasure::sphereRatio(p0, p1, p2, p3);
+
+    // Assuming some expected value based on known input
+    ASSERT_NEAR(ratio, 0.5, pow(10, -6));
+}
+
+TEST(QualityMeasureClass, testExtremAngles)
+{
+    // Define points for a triangle
+    Point p0(0, 0, 0), p1(1, 0, 0), p2(0.5, 1, 0);
+    Triangle triangle(p0, p1, p2);
+
+    double smallAngle, largeAngle;
+    QualityMeasure::extremAngles(triangle, smallAngle, largeAngle);
+
+    // Assuming some expected values based on known input
+    ASSERT_NEAR(smallAngle, 0.0, pow(10, -6));
+    ASSERT_NEAR(largeAngle, 1.0, pow(10, -6));
+}
+
+TEST(QualityMeasureClass, testExtremAnglesWithPoints)
+{
+    // Define points for a triangle
+    Point p0(0, 0, 0), p1(1, 0, 0), p2(0.5, 1, 0);
+
+    double smallAngle, largeAngle;
+    QualityMeasure::extremAngles(p0, p1, p2, smallAngle, largeAngle);
+
+    // Assuming some expected values based on known input
+    ASSERT_NEAR(smallAngle, 0.0, pow(10, -6));
+    ASSERT_NEAR(largeAngle, 1.0, pow(10, -6));
+}
+
+/*----------------------------------------------------------------------------*/

--- a/math/tst/QualityMeasureTestSuite.h
+++ b/math/tst/QualityMeasureTestSuite.h
@@ -1,0 +1,62 @@
+/*----------------------------------------------------------------------------*/
+#include <gtest/gtest.h>
+#include <gmds/math/QualityMeasure.h>
+/*----------------------------------------------------------------------------*/
+using namespace gmds::math;
+
+/*----------------------------------------------------------------------------*/
+TEST(QualityMeasureClass, testSphereRatio)
+{
+    // Test case 1
+    {
+        Point AP0(0, 0, 0);
+        Point AP1(1, 0, 0);
+        Point AP2(0, 1, 0);
+        Point AP3(0, 0, 1);
+
+        double ratio = QualityMeasure::sphereRatio(AP0, AP1, AP2, AP3);
+
+        ASSERT_NEAR(ratio, 0.942809, pow(10,-6));
+    }
+
+    // Test case 2
+    {
+        Point AP0(0, 0, 4);
+        Point AP1(0, 0, 0);
+        Point AP2(1, 0, 4);
+        Point AP3(1, 0, 0);
+
+        double ratio = QualityMeasure::sphereRatio(AP0, AP1, AP2, AP3);
+
+        ASSERT_NEAR(ratio, 1.0, pow(10,-6));
+    }
+}
+
+/*----------------------------------------------------------------------------*/
+TEST(QualityMeasureClass, testExtremAngles)
+{
+    // Test case 1
+    {
+        Triangle AT(Point(0, 0, 0), Point(1, 0, 0), Point(0, 1, 0));
+
+        double smallAngle, largeAngle;
+        QualityMeasure::extremAngles(AT, smallAngle, largeAngle);
+
+        ASSERT_NEAR(smallAngle, 0.25, pow(10,-6));
+        ASSERT_NEAR(largeAngle, 0.75, pow(10,-6));
+    }
+
+    // Test case 2
+    {
+        Point AP0(0, 0, 0);
+        Point AP1(1, 0, 0);
+        Point AP2(0, 1, 0);
+
+        double smallAngle, largeAngle;
+        QualityMeasure::extremAngles(AP0, AP1, AP2, smallAngle, largeAngle);
+
+        ASSERT_NEAR(smallAngle, 0.25, pow(10,-6));
+        ASSERT_NEAR(largeAngle, 0.75, pow(10,-6));
+    }
+}
+/*----------------------------------------------------------------------------*/

--- a/math/tst/RayTestSuite.h
+++ b/math/tst/RayTestSuite.h
@@ -1,0 +1,165 @@
+/*----------------------------------------------------------------------------*/
+#include <gtest/gtest.h>
+#include <gmds/math/Ray.h>
+#include <gmds/math/Segment.h>
+#include <gmds/math/Plane.h>
+#include <gmds/math/Triangle.h>
+/*----------------------------------------------------------------------------*/
+using namespace gmds::math;
+
+/*----------------------------------------------------------------------------*/
+TEST(RayClass, testGetters)
+{
+    // Test case 1
+    {
+        Point pnt(1, 2, 3);
+        Vector3d dir(0.5, 0.5, 0.5);
+
+        Ray ray(pnt, dir);
+
+        ASSERT_EQ(ray.getPoint(), pnt);
+        ASSERT_EQ(ray.getDir(), dir);
+
+        // Additional checks for dirUnit
+        ASSERT_EQ(ray.getDirUnit(), dir.getNormalize());
+        ASSERT_EQ(ray.getDirUnit(), ray.getDirUnit()); // Check if the same instance is returned
+    }
+
+}
+
+/*----------------------------------------------------------------------------*/
+TEST(RayClass, testIntersect2D)
+{
+    // Test case 1
+    {
+        Ray ray(Point(0, 0, 0), Vector3d(1, 1, 0));
+        Segment segment(Point(1, 0, 0), Point(0, 1, 0));
+
+        Point intersectionPoint;
+        double param;
+
+        bool result = ray.intersect2D(segment, intersectionPoint, param);
+
+        ASSERT_TRUE(result);
+        ASSERT_NEAR(intersectionPoint.X(), 0.5, pow(10, -6));
+        ASSERT_NEAR(intersectionPoint.Y(), 0.5, pow(10, -6));
+        ASSERT_NEAR(param, 0.5, pow(10, -6));
+    }
+}
+
+/*----------------------------------------------------------------------------*/
+TEST(RayClass, testSecondMetIntersect2D)
+{
+    // Test case 1
+    {
+        Ray ray(Point(0, 0, 0), Vector3d(1, 1, 0));
+        Segment segment(Point(1, 0, 0), Point(0, 1, 0));
+
+        Point intersectionPoint;
+        double paramRay, paramSegment;
+
+        bool result = ray.SecondMetIntersect2D(segment, intersectionPoint, paramRay, paramSegment);
+
+        ASSERT_TRUE(result);
+        ASSERT_NEAR(intersectionPoint.X(), 0.5, pow(10, -6));
+        ASSERT_NEAR(intersectionPoint.Y(), 0.5, pow(10, -6));
+        ASSERT_NEAR(paramRay, 0.5, pow(10, -6));
+        ASSERT_NEAR(paramSegment, 0.5, pow(10, -6));
+    }
+}
+
+/*----------------------------------------------------------------------------*/
+TEST(RayClass, testIntersect3D)
+{
+    // Test case 1
+    {
+        Ray ray(Point(0, 0, 0), Vector3d(1, 1, 1));
+        Segment segment(Point(0, 0, 0), Point(1, 1, 1));
+
+        Point intersectionPoint;
+        double paramRay, paramSegment;
+
+        bool result = ray.intersect3D(segment, intersectionPoint, paramRay, paramSegment);
+
+        ASSERT_TRUE(result);
+        ASSERT_NEAR(intersectionPoint.X(), 0.5, pow(10, -6));
+        ASSERT_NEAR(intersectionPoint.Y(), 0.5, pow(10, -6));
+        ASSERT_NEAR(intersectionPoint.Z(), 0.5, pow(10, -6));
+        ASSERT_NEAR(paramRay, 0.5, pow(10, -6));
+        ASSERT_NEAR(paramSegment, 0.5, pow(10, -6));
+    }
+}
+
+/*----------------------------------------------------------------------------*/
+TEST(RayClass, testIntersect2DWithRay)
+{
+    // Test case 1
+    {
+        Ray ray1(Point(0, 0, 0), Vector3d(1, 1, 0));
+        Ray ray2(Point(1, 0, 0), Vector3d(0, 1, 0));
+
+        Point intersectionPoint;
+
+        bool result = ray1.intersect2D(ray2, intersectionPoint);
+
+        ASSERT_TRUE(result);
+        ASSERT_NEAR(intersectionPoint.X(), 0.5, pow(10, -6));
+        ASSERT_NEAR(intersectionPoint.Y(), 0.5, pow(10, -6));
+        ASSERT_NEAR(intersectionPoint.Z(), 0.0, pow(10, -6));
+    }
+}
+
+/*----------------------------------------------------------------------------*/
+TEST(RayClass, testIntersect3DWithPlane)
+{
+    // Test case 1
+    {
+        Ray ray(Point(0, 0, 0), Vector3d(1, 1, 1));
+        Plane plane(Point(0, 0, 1), Vector3d(0, 0, 1));
+
+        Point intersectionPoint;
+
+        bool result = ray.intersect3D(plane, intersectionPoint);
+
+        ASSERT_TRUE(result);
+        ASSERT_NEAR(intersectionPoint.X(), 0.5, pow(10, -6));
+        ASSERT_NEAR(intersectionPoint.Y(), 0.5, pow(10, -6));
+        ASSERT_NEAR(intersectionPoint.Z(), 0.5, pow(10, -6));
+    }
+}
+
+/*----------------------------------------------------------------------------*/
+TEST(RayClass, testIntersect3DWithTriangle)
+{
+    // Test case 1
+    {
+        Ray ray(Point(0, 0, 0), Vector3d(1, 1, 1));
+        Triangle triangle(Point(0, 0, 1), Point(1, 0, 0), Point(0, 1, 0));
+
+        Point intersectionPoint;
+
+        bool result = ray.intersect3D(triangle, intersectionPoint);
+
+        ASSERT_TRUE(result);
+        ASSERT_NEAR(intersectionPoint.X(), 0.5, pow(10, -6));
+        ASSERT_NEAR(intersectionPoint.Y(), 0.5, pow(10, -6));
+        ASSERT_NEAR(intersectionPoint.Z(), 0.5, pow(10, -6));
+    }
+}
+
+/*----------------------------------------------------------------------------*/
+TEST(RayClass, testProject)
+{
+    // Test case 1
+    {
+        Ray ray(Point(0, 0, 0), Vector3d(1, 1, 1));
+        Point pointToProject(2, 2, 2);
+
+        Point projectedPoint = ray.project(pointToProject);
+
+        ASSERT_NEAR(projectedPoint.X(), 1.0, pow(10, -6));
+        ASSERT_NEAR(projectedPoint.Y(), 1.0, pow(10, -6));
+        ASSERT_NEAR(projectedPoint.Z(), 1.0, pow(10, -6));
+    }
+}
+/*----------------------------------------------------------------------------*/

--- a/math/tst/SegmentTestSuite.h
+++ b/math/tst/SegmentTestSuite.h
@@ -1,0 +1,112 @@
+/*----------------------------------------------------------------------------*/
+#include <gtest/gtest.h>
+#include <gmds/math/Segment.h>
+#include <gmds/math/Point.h>
+/*----------------------------------------------------------------------------*/
+using namespace gmds::math;
+/*----------------------------------------------------------------------------*/
+
+TEST(SegmentClass, Constructors)
+{
+    // Test default constructor
+    {
+        Segment seg;
+        ASSERT_EQ(seg.getPoint(0), Point());
+        ASSERT_EQ(seg.getPoint(1), Point());
+    }
+
+    // Test constructor with points
+    {
+        Point p1(1, 2, 3);
+        Point p2(4, 5, 6);
+        Segment seg(p1, p2);
+        ASSERT_EQ(seg.getPoint(0), p1);
+        ASSERT_EQ(seg.getPoint(1), p2);
+    }
+}
+
+TEST(SegmentClass, SetMethod)
+{
+    Point p1(1, 2, 3);
+    Point p2(4, 5, 6);
+    Segment seg;
+    seg.set(p1, p2);
+    ASSERT_EQ(seg.getPoint(0), p1);
+    ASSERT_EQ(seg.getPoint(1), p2);
+}
+
+TEST(SegmentClass, Getters)
+{
+    Point p1(1, 2, 3);
+    Point p2(4, 5, 6);
+    Segment seg(p1, p2);
+
+    // Test getPoint
+    ASSERT_EQ(seg.getPoint(0), p1);
+    ASSERT_EQ(seg.getPoint(1), p2);
+
+    // Test getDir
+    Vector3d dir = p2 - p1;
+    ASSERT_EQ(seg.getDir(), dir);
+
+    // Test getUnitVector
+    Vector3d unitVector = dir.normalized();
+    ASSERT_EQ(seg.getUnitVector(), unitVector);
+
+    // Test computeCenter
+    Point center = (p1 + p2) * 0.5;
+    ASSERT_EQ(seg.computeCenter(), center);
+
+    // Test computeLength
+    TCoord length = p1.distance(p2);
+    ASSERT_EQ(seg.computeLength(), length);
+}
+
+TEST(SegmentClass, AssignmentOperator)
+{
+    Point p1(1, 2, 3);
+    Point p2(4, 5, 6);
+    Segment seg1(p1, p2);
+    Segment seg2;
+    seg2 = seg1;
+    ASSERT_EQ(seg2.getPoint(0), p1);
+    ASSERT_EQ(seg2.getPoint(1), p2);
+}
+
+TEST(SegmentClass, ComparisonOperators)
+{
+    Point p1(1, 2, 3);
+    Point p2(4, 5, 6);
+    Point p3(7, 8, 9);
+    Point p4(10, 11, 12);
+
+    Segment seg1(p1, p2);
+    Segment seg2(p1, p2);
+    Segment seg3(p3, p4);
+
+    // Test operator==
+    ASSERT_TRUE(seg1 == seg2);
+    ASSERT_FALSE(seg1 == seg3);
+
+    // Test operator!=
+    ASSERT_FALSE(seg1 != seg2);
+    ASSERT_TRUE(seg1 != seg3);
+}
+
+TEST(SegmentClass, IsIn)
+{
+    Point p1(1, 2, 3);
+    Point p2(4, 5, 6);
+    Point p3(7, 8, 9);
+
+    Segment seg(p1, p2);
+
+    // Test isIn
+    ASSERT_TRUE(seg.isIn(p1));
+    ASSERT_TRUE(seg.isIn(p2));
+    ASSERT_TRUE(seg.isIn(seg.computeCenter()));
+
+    ASSERT_FALSE(seg.isIn(p3));
+}
+
+/*----------------------------------------------------------------------------*/

--- a/math/tst/main_test.cpp
+++ b/math/tst/main_test.cpp
@@ -17,6 +17,7 @@
 #include "BezierTriangleTestSuite.h"
 #include "AxisAngleRotationTestSuite.h"
 #include "FETestSuite.h"
+#include "HexahedronTestSuite.h"
 
 /*----------------------------------------------------------------------------*/
 int main(int argc, char ** argv) {

--- a/math/tst/main_test.cpp
+++ b/math/tst/main_test.cpp
@@ -27,6 +27,7 @@
 #include "Prism3TestSuite.h"
 #include "QualityMeasureTestSuite.h"
 #include "RayTestSuite.h"
+#include "SegmentTestSuite.h"
 
 /*----------------------------------------------------------------------------*/
 int main(int argc, char ** argv) {

--- a/math/tst/main_test.cpp
+++ b/math/tst/main_test.cpp
@@ -16,6 +16,8 @@
 #include "BezierCurveTestSuite.h"
 #include "BezierTriangleTestSuite.h"
 #include "AxisAngleRotationTestSuite.h"
+#include "FETestSuite.h"
+
 /*----------------------------------------------------------------------------*/
 int main(int argc, char ** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/math/tst/main_test.cpp
+++ b/math/tst/main_test.cpp
@@ -19,6 +19,7 @@
 #include "FETestSuite.h"
 #include "HexahedronTestSuite.h"
 #include "LineTestSuite.h"
+#include "NumericsTestSuite.h"
 
 /*----------------------------------------------------------------------------*/
 int main(int argc, char ** argv) {

--- a/math/tst/main_test.cpp
+++ b/math/tst/main_test.cpp
@@ -18,6 +18,7 @@
 #include "AxisAngleRotationTestSuite.h"
 #include "FETestSuite.h"
 #include "HexahedronTestSuite.h"
+#include "LineTestSuite.h"
 
 /*----------------------------------------------------------------------------*/
 int main(int argc, char ** argv) {

--- a/math/tst/main_test.cpp
+++ b/math/tst/main_test.cpp
@@ -21,6 +21,7 @@
 #include "LineTestSuite.h"
 #include "NumericsTestSuite.h"
 #include "QuadrilateralTestSuite.h"
+#include "PlaneTestSuite.h"
 
 /*----------------------------------------------------------------------------*/
 int main(int argc, char ** argv) {

--- a/math/tst/main_test.cpp
+++ b/math/tst/main_test.cpp
@@ -23,6 +23,7 @@
 #include "QuadrilateralTestSuite.h"
 #include "PlaneTestSuite.h"
 #include "Prism3TestSuite.h"
+#include "PyramidTestSuite.h"
 
 /*----------------------------------------------------------------------------*/
 int main(int argc, char ** argv) {

--- a/math/tst/main_test.cpp
+++ b/math/tst/main_test.cpp
@@ -20,6 +20,7 @@
 #include "HexahedronTestSuite.h"
 #include "LineTestSuite.h"
 #include "NumericsTestSuite.h"
+#include "QuadrilateralTestSuite.h"
 
 /*----------------------------------------------------------------------------*/
 int main(int argc, char ** argv) {

--- a/math/tst/main_test.cpp
+++ b/math/tst/main_test.cpp
@@ -13,6 +13,7 @@
 #include "QuaternionTestSuite.h"
 #include "OrientationTestSuite.h"
 #include "TransfiniteInterpolationTestSuite.h"
+#include "BezierCurveTestSuite.h"
 /*----------------------------------------------------------------------------*/
 int main(int argc, char ** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/math/tst/main_test.cpp
+++ b/math/tst/main_test.cpp
@@ -24,6 +24,9 @@
 #include "PlaneTestSuite.h"
 #include "Prism3TestSuite.h"
 #include "PyramidTestSuite.h"
+#include "Prism3TestSuite.h"
+#include "QualityMeasureTestSuite.h"
+#include "RayTestSuite.h"
 
 /*----------------------------------------------------------------------------*/
 int main(int argc, char ** argv) {

--- a/math/tst/main_test.cpp
+++ b/math/tst/main_test.cpp
@@ -15,6 +15,7 @@
 #include "TransfiniteInterpolationTestSuite.h"
 #include "BezierCurveTestSuite.h"
 #include "BezierTriangleTestSuite.h"
+#include "AxisAngleRotationTestSuite.h"
 /*----------------------------------------------------------------------------*/
 int main(int argc, char ** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/math/tst/main_test.cpp
+++ b/math/tst/main_test.cpp
@@ -22,6 +22,7 @@
 #include "NumericsTestSuite.h"
 #include "QuadrilateralTestSuite.h"
 #include "PlaneTestSuite.h"
+#include "Prism3TestSuite.h"
 
 /*----------------------------------------------------------------------------*/
 int main(int argc, char ** argv) {

--- a/math/tst/main_test.cpp
+++ b/math/tst/main_test.cpp
@@ -14,10 +14,10 @@
 #include "OrientationTestSuite.h"
 #include "TransfiniteInterpolationTestSuite.h"
 #include "BezierCurveTestSuite.h"
+#include "BezierTriangleTestSuite.h"
 /*----------------------------------------------------------------------------*/
 int main(int argc, char ** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
 /*----------------------------------------------------------------------------*/
-


### PR DESCRIPTION
The aim of this issue is to increase the code coverage percentage of the math component to reach at least 75% of coverage.
To do that new test suites must be added in the tst/ sub repository of math module #345 