### PR TITLE
upgraded version of jwlawson/actions-setup-cmake from 1.13.1 to 2.0.2…

### DIFF
--- a/.github/workflows/continuous-windows.yml
+++ b/.github/workflows/continuous-windows.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v4
         
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v1.13.1
+      uses: jwlawson/actions-setup-cmake@v2.0.2
       with:
         cmake-version: '3.21.x'
 


### PR DESCRIPTION
… because of deprecated Node.js 16