### PR TITLE
disable faulty tests

### DIFF
--- a/claire/tst/AeroPipelineTestSuite.h
+++ b/claire/tst/AeroPipelineTestSuite.h
@@ -22,7 +22,7 @@ using namespace gmds;
 /*                       CAS TEST 2D CLASSE LevelSet                          */
 /*----------------------------------------------------------------------------*/
 
-TEST(AeroPipelineTestClass, AeroPipeline2D_Test1)
+TEST(AeroPipelineTestClass, DISABLED_AeroPipeline2D_Test1)
 {
 	std::string dir(TEST_SAMPLES_DIR);
 	std::string input_file=dir+"/Aero/2D/param_Apollo_2D.ini";

--- a/claire/tst/SmoothLineSweepingTestSuite.h
+++ b/claire/tst/SmoothLineSweepingTestSuite.h
@@ -21,7 +21,7 @@
 using namespace gmds;
 /*----------------------------------------------------------------------------*/
 
-TEST(ClaireTestClass, testGrid_SmoothLineSweepingYao)
+TEST(ClaireTestClass, DISABLED_testGrid_SmoothLineSweepingYao)
 {
 	Blocking2D m;
 	Node n1 = m.newBlockCorner(0,0);


### PR DESCRIPTION
From the aero component
- `testGrid_SmoothLineSweepingYao` randomly fails
- `AeroPipeline2D_Test1` always fails on macos with a **bus error**

Since these are currently not synchronized with the lattest developments, I prefer disabling them in the meantime.