### PR TITLE
CI: switched to spack-0.22.2 in the env_macos.sh and env_linux.sh scr…

### DIFF
--- a/.github/workflows/continuous-macos.yml
+++ b/.github/workflows/continuous-macos.yml
@@ -21,6 +21,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
 
     - name: Initialize the dev environement
       run : ./.github/workflows/env_macos.sh

--- a/.github/workflows/env_linux.sh
+++ b/.github/workflows/env_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-git clone --depth=1 -b v0.20.3 https://github.com/spack/spack.git
+git clone --depth=1 -b v0.22.2 https://github.com/spack/spack.git
 sed -i 's#"{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}"#"{name}"#g' spack/etc/spack/defaults/config.yaml
 source ./spack/share/spack/setup-env.sh
 

--- a/.github/workflows/env_macos.sh
+++ b/.github/workflows/env_macos.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-git clone --depth=1 -b v0.22.1 https://github.com/spack/spack.git
+git clone --depth=1 -b v0.22.2 https://github.com/spack/spack.git
 
 #replace the default configuration file of spack by a simpler one without hash, compiler versions, tags and so on 
 #cp /Users/runner/work/gmds/gmds/.github/workflows/misc/config-0.21.1.yaml /Users/runner/work/gmds/gmds/spack/etc/spack/defaults/config.yaml

--- a/.github/workflows/env_macos.sh
+++ b/.github/workflows/env_macos.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 git clone --depth=1 -b v0.22.2 https://github.com/spack/spack.git
 
 #replace the default configuration file of spack by a simpler one without hash, compiler versions, tags and so on 


### PR DESCRIPTION
…ipts

`spack-0.22.2` requires up to python-3.12 to work, while current `macos-latest` github hosted runners provide python-3.13, which is taken by default. Using `actions/setup-python` allows us to pick version 3.12