### PR TITLE
ubuntuCI: fails because of lcov

### DIFF
--- a/.github/workflows/continuous-ubuntu.yml
+++ b/.github/workflows/continuous-ubuntu.yml
@@ -100,6 +100,8 @@ jobs:
             ctest -C ${{ matrix.config }}
         else
             export CODACY_API_TOKEN=${{ secrets.CODACY_API_TOKEN }}
+            source /spack/share/spack/setup-env.sh
+            spack load lcov
             make code_cover_gmds
             #bash <(curl -s https://codecov.io/bash)
             #bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r code_cover_gmds.info


### PR DESCRIPTION
fix https://github.com/LIHPC-Computational-Geometry/gmds/issues/441

- this commit takes care of the missing perl dependencies when calling lcov
- running on a container with a downgraded version of `lcov`, from `2.0` to `1.16` seems to take care of the second problem 