### PR TITLE
reactivate the macOS CI

### DIFF
--- a/.github/workflows/env_macos.sh
+++ b/.github/workflows/env_macos.sh
@@ -13,4 +13,5 @@ spack repo add ./spack_recipes/meshing_supersede
 
 spack external find cmake
 spack compiler find
-spack install --only dependencies gmds+python~blocking+cgns ^cgns~mpi ^hdf5~mpi
+spack compiler remove apple-clang
+spack install --only dependencies gmds+python~blocking+cgns%gcc ^cgns~mpi ^hdf5~mpi


### PR DESCRIPTION
- The blocking component is deactivated
- pytest was missing among the installed dependencies
- switched to spack-0.23.1
